### PR TITLE
fix model loading and eval with a dynamic input size

### DIFF
--- a/mlpf/tfmodel/model.py
+++ b/mlpf/tfmodel/model.py
@@ -31,7 +31,7 @@ def pairwise_dist(A, B):
 sp_a: (nbatch, nelem, nelem) sparse distance matrices
 b: (nbatch, nelem, ncol) dense per-element feature matrices
 """
-def sparse_dense_matmult_batch(sp_a, b, nelem, ncol):
+def sparse_dense_matmult_batch(sp_a, b):
 
     dtype = b.dtype
     b = tf.cast(b, tf.float32)
@@ -48,7 +48,7 @@ def sparse_dense_matmult_batch(sp_a, b, nelem, ncol):
         return mult_slice
 
     elems = (tf.range(0, num_batches, delta=1, dtype=tf.int64), b)
-    ret = tf.map_fn(map_function, elems, fn_output_signature=tf.TensorSpec((nelem, ncol), b.dtype), back_prop=True)
+    ret = tf.map_fn(map_function, elems, fn_output_signature=tf.TensorSpec((None, None), b.dtype), back_prop=True)
     return tf.cast(ret, dtype) 
 
 class InputEncoding(tf.keras.layers.Layer):
@@ -97,7 +97,7 @@ class GHConv(tf.keras.layers.Layer):
         norm = tf.expand_dims(tf.pow(in_degrees + 1e-6, -0.5), -1)
 
         f_hom = tf.linalg.matmul(x, self.theta)
-        f_hom = sparse_dense_matmult_batch(adj, f_hom*norm, self.nelem, self.hidden_dim)*norm
+        f_hom = sparse_dense_matmult_batch(adj, f_hom*norm)*norm
 
         f_het = tf.linalg.matmul(x, self.W_h)
         gate = tf.nn.sigmoid(tf.linalg.matmul(x, self.W_t) + self.b_t)

--- a/mlpf/tfmodel/model_setup.py
+++ b/mlpf/tfmodel/model_setup.py
@@ -379,13 +379,13 @@ def freeze_model(model, config, outdir):
         tf.TensorSpec((None, None, config["dataset"]["num_input_features"]), tf.float32))
     from tensorflow.python.framework import convert_to_constants
     frozen_func = convert_to_constants.convert_variables_to_constants_v2(full_model)
-    frozen_func.graph.as_graph_def()
+    graph = tf.compat.v1.graph_util.remove_training_nodes(frozen_func.graph.as_graph_def())
     
-    tf.io.write_graph(graph_or_graph_def=frozen_func.graph,
+    tf.io.write_graph(graph_or_graph_def=graph,
       logdir="{}/model_frozen".format(outdir),
       name="frozen_graph.pb",
       as_text=False)
-    tf.io.write_graph(graph_or_graph_def=frozen_func.graph,
+    tf.io.write_graph(graph_or_graph_def=graph,
       logdir="{}/model_frozen".format(outdir),
       name="frozen_graph.pbtxt",
       as_text=True)
@@ -483,7 +483,7 @@ def main(args, yaml_path, config):
     if args.action == "train":
         dataset_def.val_filelist = dataset_def.val_filelist[:1]
 
-    for fi in dataset_def.val_filelist:
+    for fi in dataset_def.val_filelist[:1]:
         X, ygen, ycand = dataset_def.prepare_data(fi)
 
         Xs.append(np.concatenate(X))

--- a/scripts/local_test_cms_tf.sh
+++ b/scripts/local_test_cms_tf.sh
@@ -39,3 +39,5 @@ python3 mlpf/launcher.py --model-spec parameters/test-cms.yaml --action train
 
 #Generate the pred.npz file of predictions
 python3 mlpf/launcher.py --model-spec parameters/test-cms.yaml --action eval --weights ./experiments/test-*/weights-01-*.hdf5
+
+python3 scripts/test_load_tfmodel.py ./experiments/test-*/model_frozen/frozen_graph.pb

--- a/scripts/test_load_tfmodel.py
+++ b/scripts/test_load_tfmodel.py
@@ -1,0 +1,32 @@
+import tensorflow as tf
+import sys
+import numpy as np
+
+bin_size = 128
+num_features = 15
+
+def load_graph(frozen_graph_filename):
+    # We load the protobuf file from the disk and parse it to retrieve the
+    # unserialized graph_def
+    with tf.compat.v1.gfile.GFile(frozen_graph_filename, "rb") as f:
+        graph_def = tf.compat.v1.GraphDef()
+        graph_def.ParseFromString(f.read())
+
+    # Then, we can use again a convenient built-in function to import a graph_def into the
+    # current default Graph
+    with tf.Graph().as_default() as graph:
+        tf.import_graph_def(
+            graph_def,
+            input_map=None,
+            return_elements=None,
+            name="",
+            op_dict=None,
+            producer_op_list=None
+        )
+    return graph 
+
+graph = load_graph(sys.argv[1])
+
+with tf.compat.v1.Session(graph=graph) as sess:
+    out = sess.run("Identity:0", feed_dict={"x:0": np.random.randn(1, 39*bin_size, num_features)})
+    print(out)


### PR DESCRIPTION
Fixes the tf map function call, which prevented an execution with a dynamic number of input elements. Added a test for loading the model from the frozen graph and executing it as is done in CMSSW.