### PR TITLE
another minor improvement to pfcand association

### DIFF
--- a/delphes/ntuplizer.py
+++ b/delphes/ntuplizer.py
@@ -438,13 +438,12 @@ def chunks(lst, n):
         yield lst[i:i + n]
 
 if __name__ == "__main__":
-    pool = multiprocessing.Pool(15)
+    pool = multiprocessing.Pool(24)
 
     infile = sys.argv[1]
     f = ROOT.TFile.Open(infile)
     tree = f.Get("Delphes")
     num_evs = tree.GetEntries()
-    #num_evs = 10
 
     arg_list = []
     ichunk = 0


### PR DESCRIPTION
Instead of going through GenParticle links, just assign the PFCandidate to the tower with which it has the exact same eta/phi. For the delphes PF algo, this always results in an unambiguous, complete matching. This does not change the physics results (the effect is too small to notice).