### PR TITLE
Add benchmarking utilities

### DIFF
--- a/mlpf/raytune/utils.py
+++ b/mlpf/raytune/utils.py
@@ -11,6 +11,7 @@ from ray.tune.suggest.bohb import TuneBOHB
 from ray.tune.suggest.hyperopt import HyperOptSearch
 from ray.tune.suggest.nevergrad import NevergradSearch
 from ray.tune.suggest.skopt import SkOptSearch
+import nevergrad as ng
 
 # from ray.tune.suggest.hebo import HEBOSearch # HEBO is not yet supported
 

--- a/mlpf/tfmodel/callbacks.py
+++ b/mlpf/tfmodel/callbacks.py
@@ -6,6 +6,9 @@ import numpy as np
 import tensorflow as tf
 from tensorflow.keras.callbacks import ModelCheckpoint, TensorBoard
 
+import json
+import matplotlib.pyplot as plt
+from datetime import datetime
 
 class CustomTensorBoard(TensorBoard):
     """
@@ -102,3 +105,101 @@ class CustomModelCheckpoint(ModelCheckpoint):
             else:
                 with open(filepath, "wb") as f:
                     pickle.dump(self.optimizer_to_save, f)
+
+
+class BenchmarkLogggerCallback(tf.keras.callbacks.Callback):
+    def __init__(self, *args, **kwargs):
+        # Added arguments
+        self.outdir = kwargs.pop("outdir")
+        self.steps_per_epoch = kwargs.pop("steps_per_epoch")
+        self.batch_size_per_gpu = kwargs.pop("batch_size_per_gpu")
+        self.num_gpus = kwargs.pop("num_gpus")
+        self.num_devices = kwargs.pop("num_devices")
+        self.train_set_size = kwargs.pop("train_set_size")
+
+        super().__init__(*args, **kwargs)
+
+    def on_train_begin(self, logs=None):
+        self.times = []
+        self.start_time = tf.timestamp().numpy()
+
+    def on_epoch_begin(self, epoch, logs=None):
+        self.epoch_time_start = tf.timestamp().numpy()
+
+    def on_epoch_end(self, epoch, logs=None):
+        self.times.append(tf.timestamp().numpy() - self.epoch_time_start)
+
+    def plot(self, times):
+        plt.figure()
+        plt.xlabel('Epoch')
+        plt.ylabel('Time [s]')
+        plt.plot(times, 'o')
+        for i in range(len(times)):
+            if isinstance(times[i], tf.Tensor):
+                j = times[i].numpy()
+            else:
+                j = times[i]
+            if i == 0:
+                plt.text(i+0.02, j+0.2, str(round(j, 2)))
+            else:
+                if isinstance(times[i-1], tf.Tensor):
+                    j_prev = times[i-1].numpy()
+                else:
+                    j_prev = times[i-1]
+                plt.text(i+0.02, j+0.2, str(round(j-j_prev, 2)))
+        plt.ylim(bottom=0)
+        txt = "Time in seconds per epoch. The numbers next to each data point\nshow the difference in seconds compared to the previous epoch."
+        plt.title(txt)
+
+        filename = "time_per_epoch_" + datetime.now().strftime("%Y%m%d%H%M%S") + ".png"
+        save_path = Path(self.outdir) / filename
+        print("Saving plot in {}".format(save_path))
+        plt.savefig(save_path)
+
+    def on_train_end(self, logs=None):
+        # class methods already do this (eg plot() ) - maybe cast in __init__
+        result_path = Path(self.outdir, "result.json")
+        stop_time = tf.timestamp().numpy()
+        total_time = round(stop_time - self.start_time, 2)
+
+        # event throughput [1/s]
+        #   - ignore batch padding
+        throughput_per_epoch = self.train_set_size / np.array(self.times)
+
+        # mean throughput
+        #   - ignore first epoch (lazy graph construction)
+        mean_throughput = round(np.mean(throughput_per_epoch[1:]), 2)
+
+        # mean epoch time
+        #   - ignore first epoch (lazy graph construction)
+        mean_epoch_time = round(np.mean(self.times[1:]), 2)
+        batch_size_total = self.batch_size_per_gpu * (self.num_gpus or self.num_devices)
+
+        data = {
+            "wl-scores": {
+                "mean_throughput": mean_throughput,
+                "mean_epoch_time": mean_epoch_time,
+            },
+            "wl-stats": {
+                "num_epochs": len(self.times),
+                "epoch_times": self.times,
+                "train_start": self.start_time,
+                "train_stop": stop_time,
+                "train_time": total_time,
+                "GPU": self.num_gpus,
+                "CPU": self.num_devices,
+                "train_set_size": self.train_set_size,
+                "batch_size_per_device": self.batch_size_per_gpu,
+                "batch_size_total": batch_size_total,
+                "steps_per_epoch": self.steps_per_epoch,
+                "events_per_epoch": batch_size_total * self.steps_per_epoch,
+                "throughput_per_epoch": list(throughput_per_epoch),
+            },
+        }
+
+        print("Saving result to {}".format(result_path.resolve()))
+        with result_path.open("w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False, indent=4)
+
+        # may not be needed for later versions
+        self.plot(self.times)

--- a/mlpf/tfmodel/utils.py
+++ b/mlpf/tfmodel/utils.py
@@ -123,7 +123,7 @@ def delete_all_but_best_checkpoint(train_dir, dry_run):
         print("Removed all checkpoints in {} except {}".format(train_dir, best_ckpt))
 
 
-def get_strategy():
+def get_strategy(num_devices=1):
     if isinstance(os.environ.get("CUDA_VISIBLE_DEVICES"), type(None)) or len(os.environ.get("CUDA_VISIBLE_DEVICES")) == 0:
         gpus = [-1]
         print(
@@ -137,16 +137,23 @@ def get_strategy():
     else:
         num_gpus = len(gpus)
     print("num_gpus=", num_gpus)
+
     if num_gpus > 1:
-        print("Using tf.distribute.MirroredStrategy()")
+        # multiple GPUs selected
+        print("Attempting to use multiple GPUs with tf.distribute.MirroredStrategy()...")
+        strategy = tf.distribute.MirroredStrategy(["gpu:{}".format(g) for g in gpus])
+    elif num_devices > 1:
+        # CPU parallelization
+        print("Attempting CPU parallelization with tf.distribute.MirroredStrategy()...")
         strategy = tf.distribute.MirroredStrategy()
     elif num_gpus == 1:
-        print("Using tf.distribute.OneDeviceStrategy('gpu:0')")
-        strategy = tf.distribute.OneDeviceStrategy("gpu:0")
-    elif num_gpus == 0:
-        print("fallback to CPU")
+        # single GPU
+        print("Using a single GPU with tf.distribute.OneDeviceStrategy()")
+        strategy = tf.distribute.OneDeviceStrategy("gpu:{}".format(gpus[0]))
+    else:
+        print("Fallback to CPU")
         strategy = tf.distribute.OneDeviceStrategy("cpu")
-        num_gpus = 0
+
     return strategy, num_gpus
 
 
@@ -190,6 +197,7 @@ def get_lr_schedule(config, steps):
             decay_steps=steps,
         )
     else:
+        print("INFO: Not using LR schedule")
         lr_schedule = None
         callbacks = []
     return lr_schedule, callbacks, lr
@@ -335,30 +343,33 @@ def load_and_interleave(dataset_names, config, num_gpus, split, batch_size):
         if num_gpus > 1:
             bs = bs * num_gpus
     ds = ds.batch(bs)
+    # return ds, len(indices)  #  From Eduard's bmk branch
 
     total_num_steps = total_num_steps // bs
     # num_steps = 0
     # for _ in ds:
     #    num_steps += 1
     # assert(total_num_steps == num_steps)
-    return ds, total_num_steps
+    return ds, total_num_steps, len(indices)  #  TODO: revisit the need to return `len(indices)`
 
 
 # Load multiple datasets and mix them together
 def get_datasets(datasets_to_interleave, config, num_gpus, split):
     datasets = []
     steps = []
+    num_samples = 0
     for joint_dataset_name in datasets_to_interleave.keys():
         ds_conf = datasets_to_interleave[joint_dataset_name]
         if ds_conf["datasets"] is None:
             logging.warning("No datasets in {} list.".format(joint_dataset_name))
         else:
-            interleaved_ds, num_steps = load_and_interleave(
+            interleaved_ds, num_steps, ds_samples = load_and_interleave(
                 ds_conf["datasets"], config, num_gpus, split, ds_conf["batch_per_gpu"]
             )
             print("Interleaved joint dataset {} with {} steps".format(joint_dataset_name, num_steps))
             datasets.append(interleaved_ds)
             steps.append(num_steps)
+            num_samples += ds_samples
 
     ids = 0
     indices = []
@@ -378,7 +389,7 @@ def get_datasets(datasets_to_interleave, config, num_gpus, split):
     # assert(total_num_steps == num_steps)
 
     print("Final dataset with {} steps".format(total_num_steps))
-    return ds, total_num_steps
+    return ds, total_num_steps, num_samples
 
 
 def set_config_loss(config, trainable):

--- a/parameters/delphes-bench.yaml
+++ b/parameters/delphes-bench.yaml
@@ -1,0 +1,230 @@
+backend: tensorflow
+
+dataset:
+  schema: delphes
+  target_particles: gen
+  num_input_features: 12
+  num_output_features: 7
+  #(none=0, track=1, cluster=2)
+  num_input_classes: 3
+  #(none=0, charged hadron=1, neutral hadron=2, photon=3, electron=4, muon=5) 
+  num_output_classes: 6
+  num_momentum_outputs: 5
+  padded_num_elem_size: 6400
+  classification_loss_coef: 1.0
+  charge_loss_coef: 1.0
+  pt_loss_coef: 100.0
+  eta_loss_coef: 100.0
+  sin_phi_loss_coef: 100.0
+  cos_phi_loss_coef: 100.0
+  energy_loss_coef: 100.0
+  energy_loss:
+    type: Huber
+    delta: 1.0
+  pt_loss:
+    type: Huber
+    delta: 1.0
+  sin_phi_loss:
+    type: Huber
+    delta: 0.1
+  cos_phi_loss:
+    type: Huber
+    delta: 0.1
+  eta_loss:
+    type: Huber
+    delta: 0.1
+
+tensorflow:
+  eager: no
+
+setup:
+  train: yes
+  weights:
+  weights_config:
+  lr: 1e-4
+  num_events_train: 45000
+  num_events_test: 5000
+  num_events_validation: 5000
+  num_epochs: 10
+  num_val_files: 5
+  dtype: float32
+  trainable:
+  classification_loss_type: categorical_cross_entropy
+  lr_schedule: exponentialdecay  # exponentialdecay, onecycle
+  optimizer: adam  # adam, adamw, sgd
+
+optimizer:
+  adam:
+    amsgrad: no
+  adamw:
+    amsgrad: yes
+    weight_decay: 0.001
+  sgd:
+    nesterov: no
+    momentum: 0.9
+
+# LR Schedules
+exponentialdecay:
+  decay_steps: 10000
+  decay_rate: 0.99
+  staircase: yes
+onecycle:
+  mom_min: 0.85
+  mom_max: 0.95
+  warmup_ratio: 0.3
+  div_factor: 25.0
+  final_div: 100000.0
+
+sample_weights:
+  cls: inverse_sqrt
+  charge: signal_only
+  pt: signal_only
+  eta: signal_only
+  sin_phi: signal_only
+  cos_phi: signal_only
+  energy: signal_only
+
+parameters:
+  model: gnn_dense
+  input_encoding: default
+  node_update_mode: concat
+  do_node_encoding: no
+  node_encoding_hidden_dim: 128
+  combined_graph_layer:
+    bin_size: 640
+    max_num_bins: 100
+    distance_dim: 128
+    layernorm: no
+    num_node_messages: 1
+    dropout: 0.0
+    dist_activation: linear
+    ffn_dist_num_layers: 1
+    ffn_dist_hidden_dim: 128
+    kernel:
+      type: NodePairGaussianKernel
+      dist_mult: 0.1
+      clip_value_low: 0.0
+    node_message:
+      type: GHConvDense
+      output_dim: 256
+      activation: elu
+      normalize_degrees: yes
+    activation: elu
+  num_graph_layers_common: 3
+  num_graph_layers_energy: 3
+  output_decoding:
+    activation: elu
+    regression_use_classification: yes
+    dropout: 0.0
+
+    pt_skip_gate: yes
+    eta_skip_gate: yes
+    phi_skip_gate: yes
+
+    id_dim_decrease: yes
+    charge_dim_decrease: yes
+    pt_dim_decrease: yes
+    eta_dim_decrease: yes
+    phi_dim_decrease: yes
+    energy_dim_decrease: yes
+
+    id_hidden_dim: 256
+    charge_hidden_dim: 256
+    pt_hidden_dim: 256
+    eta_hidden_dim: 256
+    phi_hidden_dim: 256
+    energy_hidden_dim: 256
+
+    id_num_layers: 4
+    charge_num_layers: 2
+    pt_num_layers: 3
+    eta_num_layers: 3
+    phi_num_layers: 3
+    energy_num_layers: 3
+    layernorm: yes
+    mask_reg_cls0: no
+
+  skip_connection: yes
+  debug: no
+
+timing:
+  num_ev: 100
+  num_iter: 3
+
+exponentialdecay:
+  decay_steps: 10000
+  decay_rate: 0.99
+  staircase: yes
+
+callbacks:
+  checkpoint:
+    save_weights_only: yes
+    monitor: "val_loss"
+    save_best_only: no
+  plot_freq: 10
+  tensorboard:
+    dump_history: yes
+    hist_freq: 1
+
+hypertune:
+  algorithm: hyperband  # random, bayesian, hyperband
+  random:
+    objective: val_loss
+    max_trials: 100
+  bayesian:
+    objective: val_loss
+    max_trials: 100
+    num_initial_points: 2
+  hyperband:
+    objective: val_loss
+    max_epochs: 100
+    factor: 3
+    iterations: 1
+    executions_per_trial: 1
+
+raytune:
+  local_dir:  # Note: please specify an absolute path
+  sched: "asha"  # asha, hyperband
+  parameters:
+    # optimizer parameters
+    lr: [1e-4]
+    batch_size: [32]
+    expdecay_decay_steps: [10000]
+    # model parameters
+    combined_graph_layer:
+      layernorm: [False]
+      hidden_dim: [64, 128, 256]
+      distance_dim: [128, 256]
+      num_node_messages: [1]
+      node_message:
+        normalize_degrees: [True]
+        output_dim: [64, 128, 256]
+      dropout: [0.0]
+      bin_size: [80, 160, 320]
+      kernel:
+        clip_value_low: [0.0]
+    num_graph_layers_common: [2, 3, 4]
+    num_graph_layers_energy: [2, 3, 4]
+  # Tune schedule specific parameters
+  asha:
+    max_t: 100
+    reduction_factor: 3
+    brackets: 1
+    grace_period: 5
+  hyperband:
+    max_t: 100
+    reduction_factor: 3
+
+train_test_datasets:
+  delphes: 
+    batch_per_gpu: 5
+    datasets:
+      - delphes_pf
+
+validation_dataset: delphes_pf
+
+datasets:
+  delphes_pf:
+    version: 1.0.1
+    data_dir: ../tensorflow_datasets
+    manual_dir:

--- a/parameters/delphes-benchmark.yaml
+++ b/parameters/delphes-benchmark.yaml
@@ -1,0 +1,230 @@
+backend: tensorflow
+
+dataset:
+  schema: delphes
+  target_particles: gen
+  num_input_features: 12
+  num_output_features: 7
+  #(none=0, track=1, cluster=2)
+  num_input_classes: 3
+  #(none=0, charged hadron=1, neutral hadron=2, photon=3, electron=4, muon=5) 
+  num_output_classes: 6
+  num_momentum_outputs: 5
+  padded_num_elem_size: 6400
+  classification_loss_coef: 1.0
+  charge_loss_coef: 1.0
+  pt_loss_coef: 100.0
+  eta_loss_coef: 100.0
+  sin_phi_loss_coef: 100.0
+  cos_phi_loss_coef: 100.0
+  energy_loss_coef: 100.0
+  energy_loss:
+    type: Huber
+    delta: 1.0
+  pt_loss:
+    type: Huber
+    delta: 1.0
+  sin_phi_loss:
+    type: Huber
+    delta: 0.1
+  cos_phi_loss:
+    type: Huber
+    delta: 0.1
+  eta_loss:
+    type: Huber
+    delta: 0.1
+
+tensorflow:
+  eager: no
+
+setup:
+  train: yes
+  weights:
+  weights_config:
+  lr: 1e-4
+  num_events_train: 45000
+  num_events_test: 5000
+  num_events_validation: 5000
+  num_epochs: 10
+  num_val_files: 5
+  dtype: float32
+  trainable:
+  classification_loss_type: categorical_cross_entropy
+  lr_schedule: exponentialdecay  # exponentialdecay, onecycle
+  optimizer: adam  # adam, adamw, sgd
+
+optimizer:
+  adam:
+    amsgrad: no
+  adamw:
+    amsgrad: yes
+    weight_decay: 0.001
+  sgd:
+    nesterov: no
+    momentum: 0.9
+
+# LR Schedules
+exponentialdecay:
+  decay_steps: 10000
+  decay_rate: 0.99
+  staircase: yes
+onecycle:
+  mom_min: 0.85
+  mom_max: 0.95
+  warmup_ratio: 0.3
+  div_factor: 25.0
+  final_div: 100000.0
+
+sample_weights:
+  cls: inverse_sqrt
+  charge: signal_only
+  pt: signal_only
+  eta: signal_only
+  sin_phi: signal_only
+  cos_phi: signal_only
+  energy: signal_only
+
+parameters:
+  model: gnn_dense
+  input_encoding: default
+  node_update_mode: concat
+  do_node_encoding: no
+  node_encoding_hidden_dim: 128
+  combined_graph_layer:
+    bin_size: 640
+    max_num_bins: 100
+    distance_dim: 128
+    layernorm: no
+    num_node_messages: 1
+    dropout: 0.0
+    dist_activation: linear
+    ffn_dist_num_layers: 1
+    ffn_dist_hidden_dim: 128
+    kernel:
+      type: NodePairGaussianKernel
+      dist_mult: 0.1
+      clip_value_low: 0.0
+    node_message:
+      type: GHConvDense
+      output_dim: 256
+      activation: elu
+      normalize_degrees: yes
+    activation: elu
+  num_graph_layers_common: 3
+  num_graph_layers_energy: 3
+  output_decoding:
+    activation: elu
+    regression_use_classification: yes
+    dropout: 0.0
+
+    pt_skip_gate: yes
+    eta_skip_gate: yes
+    phi_skip_gate: yes
+
+    id_dim_decrease: yes
+    charge_dim_decrease: yes
+    pt_dim_decrease: yes
+    eta_dim_decrease: yes
+    phi_dim_decrease: yes
+    energy_dim_decrease: yes
+
+    id_hidden_dim: 256
+    charge_hidden_dim: 256
+    pt_hidden_dim: 256
+    eta_hidden_dim: 256
+    phi_hidden_dim: 256
+    energy_hidden_dim: 256
+
+    id_num_layers: 4
+    charge_num_layers: 2
+    pt_num_layers: 3
+    eta_num_layers: 3
+    phi_num_layers: 3
+    energy_num_layers: 3
+    layernorm: yes
+    mask_reg_cls0: no
+
+  skip_connection: yes
+  debug: no
+
+timing:
+  num_ev: 100
+  num_iter: 3
+
+exponentialdecay:
+  decay_steps: 10000
+  decay_rate: 0.99
+  staircase: yes
+
+callbacks:
+  checkpoint:
+    save_weights_only: yes
+    monitor: "val_loss"
+    save_best_only: no
+  plot_freq: 10
+  tensorboard:
+    dump_history: yes
+    hist_freq: 1
+
+hypertune:
+  algorithm: hyperband  # random, bayesian, hyperband
+  random:
+    objective: val_loss
+    max_trials: 100
+  bayesian:
+    objective: val_loss
+    max_trials: 100
+    num_initial_points: 2
+  hyperband:
+    objective: val_loss
+    max_epochs: 100
+    factor: 3
+    iterations: 1
+    executions_per_trial: 1
+
+raytune:
+  local_dir:  # Note: please specify an absolute path
+  sched: "asha"  # asha, hyperband
+  parameters:
+    # optimizer parameters
+    lr: [1e-4]
+    batch_size: [32]
+    expdecay_decay_steps: [10000]
+    # model parameters
+    combined_graph_layer:
+      layernorm: [False]
+      hidden_dim: [64, 128, 256]
+      distance_dim: [128, 256]
+      num_node_messages: [1]
+      node_message:
+        normalize_degrees: [True]
+        output_dim: [64, 128, 256]
+      dropout: [0.0]
+      bin_size: [80, 160, 320]
+      kernel:
+        clip_value_low: [0.0]
+    num_graph_layers_common: [2, 3, 4]
+    num_graph_layers_energy: [2, 3, 4]
+  # Tune schedule specific parameters
+  asha:
+    max_t: 100
+    reduction_factor: 3
+    brackets: 1
+    grace_period: 5
+  hyperband:
+    max_t: 100
+    reduction_factor: 3
+
+train_test_datasets:
+  delphes: 
+    batch_per_gpu: 5
+    datasets:
+      - delphes_pf
+
+validation_dataset: delphes_pf
+
+datasets:
+  delphes_pf:
+    version: 1.0.1
+    data_dir: /workspace/tensorflow_datasets
+    manual_dir:


### PR DESCRIPTION
- Benchmarking callback makes it easy to log time and throughput (i.e. batches/s or samples/s) measurements during training.
- Additional command line arguments to `pipeline.py train` to facilitate benchmarking
- Add ability to run parallelized training on CPU (i.e. treat each core as a worker)