### PR TITLE
clean up dataset prep

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
       - run: pip3 install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cpu
       - run: pip install pyg-lib torch-scatter torch-sparse torch-cluster torch-spline-conv torch-geometric -f https://data.pyg.org/whl/torch-1.13.0+cpu.html
 
-  clic-pipeline:
+  tf-clic-pipeline:
     runs-on: ubuntu-20.04
     needs: [deps]
     steps:
@@ -43,7 +43,7 @@ jobs:
       - run: pip install -r requirements.txt
       - run: ./scripts/local_test_clic_pipeline.sh
 
-  delphes-pipeline:
+  tf-delphes-pipeline:
     runs-on: ubuntu-20.04
     needs: [deps]
     steps:
@@ -55,7 +55,7 @@ jobs:
       - run: pip install -r requirements.txt
       - run: ./scripts/local_test_delphes_pipeline.sh
 
-  cms-pipeline:
+  tf-cms-pipeline:
     runs-on: ubuntu-20.04
     needs: [deps]
     steps:

--- a/mlpf/heptfds/clic_pf_edm4hep/utils_edm.py
+++ b/mlpf/heptfds/clic_pf_edm4hep/utils_edm.py
@@ -3,6 +3,9 @@ import fastjet
 import numpy as np
 import vector
 
+jetdef = fastjet.JetDefinition(fastjet.antikt_algorithm, 0.4)
+min_jet_pt = 1.0  # GeV
+
 # from fcc/postprocessing.py
 X_FEATURES_TRK = [
     "type",
@@ -61,49 +64,50 @@ def split_sample(path, test_frac=0.8):
     }
 
 
-def generate_examples(files):
-    jetdef = fastjet.JetDefinition(fastjet.antikt_algorithm, 0.4)
-    min_jet_pt = 1.0  # GeV
-    for fi in files:
-        ret = ak.from_parquet(fi)
+def prepare_data_clic(fn, with_jet_idx=True):
+    ret = ak.from_parquet(fn)
 
-        X_track = ret["X_track"]
-        X_cluster = ret["X_cluster"]
+    X_track = ret["X_track"]
+    X_cluster = ret["X_cluster"]
 
-        assert len(X_track) == len(X_cluster)
-        nev = len(X_track)
+    assert len(X_track) == len(X_cluster)
+    nev = len(X_track)
 
-        for iev in range(nev):
+    Xs = []
+    ygens = []
+    ycands = []
+    for iev in range(nev):
 
-            X1 = ak.to_numpy(X_track[iev])
-            X2 = ak.to_numpy(X_cluster[iev])
+        X1 = ak.to_numpy(X_track[iev])
+        X2 = ak.to_numpy(X_cluster[iev])
 
-            if len(X1) == 0 or len(X2) == 0:
-                continue
+        if len(X1) == 0 or len(X2) == 0:
+            continue
 
-            ygen_track = ak.to_numpy(ret["ygen_track"][iev])
-            ygen_cluster = ak.to_numpy(ret["ygen_cluster"][iev])
-            ycand_track = ak.to_numpy(ret["ycand_track"][iev])
-            ycand_cluster = ak.to_numpy(ret["ycand_cluster"][iev])
+        ygen_track = ak.to_numpy(ret["ygen_track"][iev])
+        ygen_cluster = ak.to_numpy(ret["ygen_cluster"][iev])
+        ycand_track = ak.to_numpy(ret["ycand_track"][iev])
+        ycand_cluster = ak.to_numpy(ret["ycand_cluster"][iev])
 
-            if len(ygen_track) == 0 or len(ygen_cluster) == 0:
-                continue
+        if len(ygen_track) == 0 or len(ygen_cluster) == 0:
+            continue
 
-            # pad feature dim between tracks and clusters to the same size
-            if X1.shape[1] < X2.shape[1]:
-                X1 = np.pad(X1, [[0, 0], [0, X2.shape[1] - X1.shape[1]]])
-            if X2.shape[1] < X1.shape[1]:
-                X2 = np.pad(X2, [[0, 0], [0, X1.shape[1] - X2.shape[1]]])
+        # pad feature dim between tracks and clusters to the same size
+        if X1.shape[1] < X2.shape[1]:
+            X1 = np.pad(X1, [[0, 0], [0, X2.shape[1] - X1.shape[1]]])
+        if X2.shape[1] < X1.shape[1]:
+            X2 = np.pad(X2, [[0, 0], [0, X1.shape[1] - X2.shape[1]]])
 
-            # concatenate tracks and clusters in features and targets
-            X = np.concatenate([X1, X2])
-            ygen = np.concatenate([ygen_track, ygen_cluster])
-            ycand = np.concatenate([ycand_track, ycand_cluster])
+        # concatenate tracks and clusters in features and targets
+        X = np.concatenate([X1, X2])
+        ygen = np.concatenate([ygen_track, ygen_cluster])
+        ycand = np.concatenate([ycand_track, ycand_cluster])
 
-            assert ygen.shape[0] == X.shape[0]
-            assert ycand.shape[0] == X.shape[0]
+        assert ygen.shape[0] == X.shape[0]
+        assert ycand.shape[0] == X.shape[0]
 
-            # add jet_idx column
+        # add jet_idx column
+        if with_jet_idx:
             ygen = np.concatenate(
                 [
                     ygen.astype(np.float32),
@@ -119,12 +123,13 @@ def generate_examples(files):
                 axis=-1,
             )
 
-            # replace PID with index in labels array
-            arr = np.array([labels.index(p) for p in ygen[:, 0]])
-            ygen[:, 0][:] = arr[:]
-            arr = np.array([labels.index(p) for p in ycand[:, 0]])
-            ycand[:, 0][:] = arr[:]
+        # replace PID with index in labels array
+        arr = np.array([labels.index(p) for p in ygen[:, 0]])
+        ygen[:, 0][:] = arr[:]
+        arr = np.array([labels.index(p) for p in ycand[:, 0]])
+        ycand[:, 0][:] = arr[:]
 
+        if with_jet_idx:
             # prepare gen candidates for clustering
             cls_id = ygen[..., 0]
             valid = cls_id != 0
@@ -160,11 +165,20 @@ def generate_examples(files):
                 ]  # map back to constituent index *before* masking
                 ygen[jet_constituents, Y_FEATURES.index("jet_idx")] = jet_idx + 1  # jet index starts from 1
                 ycand[jet_constituents, Y_FEATURES.index("jet_idx")] = jet_idx + 1
+        Xs.append(X)
+        ygens.append(ygen)
+        ycands.append(ycand)
+    return Xs, ygens, ycands
 
+
+def generate_examples(files, with_jet_idx=True):
+    for fi in files:
+        Xs, ygens, ycands = prepare_data_clic(fi, with_jet_idx=with_jet_idx)
+        for iev in range(len(Xs)):
             yield str(fi) + "_" + str(iev), {
-                "X": X.astype(np.float32),
-                "ygen": ygen,
-                "ycand": ycand,
+                "X": Xs[iev].astype(np.float32),
+                "ygen": ygens[iev],
+                "ycand": ycands[iev],
             }
 
 

--- a/mlpf/heptfds/delphes_pf/delphes_pf.py
+++ b/mlpf/heptfds/delphes_pf/delphes_pf.py
@@ -35,6 +35,9 @@ class DelphesPf(tfds.core.GeneratorBasedBuilder):
         "1.0.0": "Initial release.",
         "1.1.0": "Do not pad events to the same size",
     }
+    MANUAL_DOWNLOAD_INSTRUCTIONS = """
+    Download from https://zenodo.org/record/4559324#.YTs853tRVH4
+    """
 
     def _info(self) -> tfds.core.DatasetInfo:
         """Returns the dataset metadata."""
@@ -59,28 +62,10 @@ class DelphesPf(tfds.core.GeneratorBasedBuilder):
         )
 
     def _split_generators(self, dl_manager: tfds.download.DownloadManager):
-        """Returns SplitGenerators."""
-        delphes_dir = dl_manager.download_dir / "delphes_pf"
-        if delphes_dir.exists():
-            print("INFO: Data already exists. Please delete {} if you want to download data again.".format(delphes_dir))
-        else:
-            get_delphes_from_zenodo(download_dir=dl_manager.download_dir / "delphes_pf")
-
-        ttbar_dir = delphes_dir / "pythia8_ttbar/raw"
-        qcd_dir = delphes_dir / "pythia8_qcd/val"
-
-        if not ttbar_dir.exists():
-            ttbar_dir.mkdir(parents=True)
-            for ttbar_file in delphes_dir.glob("*ttbar*.pkl.bz2"):
-                ttbar_file.rename(ttbar_dir / ttbar_file.name)
-        if not qcd_dir.exists():
-            qcd_dir.mkdir(parents=True)
-            for qcd_file in delphes_dir.glob("*qcd*.pkl.bz2"):
-                qcd_file.rename(qcd_dir / qcd_file.name)
-
+        path = Path(dl_manager.manual_dir)
         return {
-            "train": self._generate_examples(delphes_dir / "pythia8_ttbar/raw"),
-            "test": self._generate_examples(delphes_dir / "pythia8_qcd/val"),
+            "train": self._generate_examples(path / "pythia8_ttbar"),
+            "test": self._generate_examples(path / "pythia8_qcd"),
         }
 
     def _generate_examples(self, path):

--- a/mlpf/heptfds/delphes_pf/delphes_pf.py
+++ b/mlpf/heptfds/delphes_pf/delphes_pf.py
@@ -1,20 +1,10 @@
-"""delphes_pf dataset."""
-import os
-import resource
 from pathlib import Path
-
 import tensorflow as tf
 import tqdm
 
 import tensorflow_datasets as tfds
 
 from delphes_utils import prepare_data_delphes, X_FEATURES, Y_FEATURES
-
-# Increase python's soft limit on number of open files to accomodate tensorflow_datasets sharding
-# https://github.com/tensorflow/datasets/issues/1441
-low, high = resource.getrlimit(resource.RLIMIT_NOFILE)
-resource.setrlimit(resource.RLIMIT_NOFILE, (high, high))
-
 
 _DESCRIPTION = """
 Dataset generated with Delphes.
@@ -24,6 +14,7 @@ TTbar and QCD events with PU~200.
 
 # TODO(delphes_pf): BibTeX citation
 _CITATION = """
+https://zenodo.org/record/4559324#.YTs853tRVH4
 """
 
 
@@ -56,7 +47,7 @@ class DelphesPf(tfds.core.GeneratorBasedBuilder):
             # features, specify them here. They'll be used if
             # `as_supervised=True` in `builder.as_dataset`.
             supervised_keys=("X", "ygen"),  # Set to `None` to disable
-            homepage="",
+            homepage="https://zenodo.org/record/4559324#.YTs853tRVH4",
             citation=_CITATION,
             metadata=tfds.core.MetadataDict(x_features=X_FEATURES),
         )
@@ -78,11 +69,3 @@ class DelphesPf(tfds.core.GeneratorBasedBuilder):
                     "ygen": ygens[iev],
                     "ycand": ycands[iev],
                 }
-
-
-def get_delphes_from_zenodo(download_dir="."):
-    # url = 'https://zenodo.org/record/4559324'
-    zenodo_doi = "10.5281/zenodo.4559324"
-    print("Downloading data from {} to {}".format(zenodo_doi, download_dir))
-    os.system("zenodo_get -d {} -o {}".format(zenodo_doi, download_dir))
-    return Path(download_dir)

--- a/mlpf/heptfds/delphes_pf/delphes_utils.py
+++ b/mlpf/heptfds/delphes_pf/delphes_utils.py
@@ -1,0 +1,142 @@
+import fastjet
+import numpy as np
+import pickle
+import bz2
+import vector
+import awkward as ak
+
+DELPHES_CLASS_NAMES = [
+    "none",
+    "charged hadron",
+    "neutral hadron",
+    "hfem",
+    "hfhad",
+    "photon",
+    "electron",
+    "muon",
+]
+
+
+# based on delphes/ntuplizer.py
+X_FEATURES = [
+    "typ_idx",
+    "pt",
+    "eta",
+    "sin_phi",
+    "cos_phi",
+    "e",
+    "eta_outer",
+    "sin_phi_outer",
+    "cos_phi_outer",
+    "charge",
+    "is_gen_muon",
+    "is_gen_electron",
+]
+
+Y_FEATURES = [
+    "type",
+    "charge",
+    "pt",
+    "eta",
+    "sin_phi",
+    "cos_phi",
+    "energy",
+    "jet_idx",
+]
+
+
+def prepare_data_delphes(fname, with_jet_idx=True):
+
+    jetdef = fastjet.JetDefinition(fastjet.antikt_algorithm, 0.4)
+    min_jet_pt = 5.0  # GeV
+
+    if fname.endswith(".pkl"):
+        data = pickle.load(open(fname, "rb"))
+    elif fname.endswith(".pkl.bz2"):
+        data = pickle.load(bz2.BZ2File(fname, "rb"))
+    else:
+        raise Exception("Unknown file: {}".format(fname))
+
+    # make all inputs and outputs the same size with padding
+    Xs = []
+    ygens = []
+    ycands = []
+    for i in range(len(data["X"])):
+        X = data["X"][i].astype(np.float32)
+        ygen = data["ygen"][i].astype(np.float32)
+        ycand = data["ycand"][i].astype(np.float32)
+
+        # add jet_idx column
+        if with_jet_idx:
+            ygen = np.concatenate(
+                [
+                    ygen.astype(np.float32),
+                    np.zeros((len(ygen), 1), dtype=np.float32),
+                ],
+                axis=-1,
+            )
+            ycand = np.concatenate(
+                [
+                    ycand.astype(np.float32),
+                    np.zeros((len(ycand), 1), dtype=np.float32),
+                ],
+                axis=-1,
+            )
+
+        # in the delphes sample, neutral PF candidates have only E defined, and charged PF candidates have only pT defined
+        # fix this up here for the delphes PF candidates
+        pz = ycand[:, Y_FEATURES.index("energy")] * np.cos(2 * np.arctan(np.exp(-ycand[:, Y_FEATURES.index("eta")])))
+        pt = np.sqrt(ycand[:, Y_FEATURES.index("energy")] ** 2 - pz**2)
+
+        # eta=atanh(pz/p) => E=pt/sqrt(1-tanh(eta))
+        e = ycand[:, Y_FEATURES.index("pt")] / np.sqrt(1.0 - np.tanh(ycand[:, Y_FEATURES.index("eta")]))
+
+        # use these computed values where they are missing
+        msk_neutral = np.abs(ycand[:, Y_FEATURES.index("charge")]) == 0
+        msk_charged = ~msk_neutral
+        ycand[:, Y_FEATURES.index("pt")] = msk_charged * ycand[:, Y_FEATURES.index("pt")] + msk_neutral * pt
+        ycand[:, Y_FEATURES.index("energy")] = msk_neutral * ycand[:, Y_FEATURES.index("energy")] + msk_charged * e
+
+        if with_jet_idx:
+            # prepare gen candidates for clustering
+            cls_id = ygen[..., 0]
+            valid = cls_id != 0
+            # save mapping of index after masking -> index before masking as numpy array
+            # inspired from:
+            # https://stackoverflow.com/questions/432112/1044443#comment54747416_1044443
+            cumsum = np.cumsum(valid) - 1
+            _, index_mapping = np.unique(cumsum, return_index=True)
+
+            pt = ygen[valid, Y_FEATURES.index("pt")]
+            eta = ygen[valid, Y_FEATURES.index("eta")]
+            phi = np.arctan2(
+                ygen[valid, Y_FEATURES.index("sin_phi")],
+                ygen[valid, Y_FEATURES.index("cos_phi")],
+            )
+            e = ygen[valid, Y_FEATURES.index("energy")]
+            vec = vector.awk(ak.zip({"pt": pt, "eta": eta, "phi": phi, "e": e}))
+
+            # cluster jets, sort jet indices in descending order by pt
+            cluster = fastjet.ClusterSequence(vec.to_xyzt(), jetdef)
+            jets = vector.awk(cluster.inclusive_jets(min_pt=min_jet_pt))
+            sorted_jet_idx = ak.argsort(jets.pt, axis=-1, ascending=False).to_list()
+            # retrieve corresponding indices of constituents
+            constituent_idx = cluster.constituent_index(min_pt=min_jet_pt).to_list()
+
+            # add index information to ygen and ycand
+            # index jets in descending order by pt starting from 1:
+            # 0 is null (unclustered),
+            # 1 is 1st highest-pt jet,
+            # 2 is 2nd highest-pt jet, ...
+            for jet_idx in sorted_jet_idx:
+                jet_constituents = [
+                    index_mapping[idx] for idx in constituent_idx[jet_idx]
+                ]  # map back to constituent index *before* masking
+                ygen[jet_constituents, Y_FEATURES.index("jet_idx")] = jet_idx + 1  # jet index starts from 1
+                ycand[jet_constituents, Y_FEATURES.index("jet_idx")] = jet_idx + 1
+
+        Xs.append(X)
+        ygens.append(ygen)
+        ycands.append(ycand)
+
+    return Xs, ygens, ycands

--- a/mlpf/pyg/args.py
+++ b/mlpf/pyg/args.py
@@ -23,7 +23,7 @@ def parse_args():
 
     # for training hyperparameters
     parser.add_argument("--n_epochs", type=int, default=3, help="number of training epochs")
-    parser.add_argument("--bs", type=int, default=100, help="number of events to run inference on before updating the loss")
+    parser.add_argument("--bs", type=int, default=100, help="training minibatch size in number of events")
     parser.add_argument("--patience", type=int, default=50, help="patience before early stopping")
     parser.add_argument("--lr", type=float, default=1e-4, help="learning rate")
 

--- a/mlpf/pyg/training.py
+++ b/mlpf/pyg/training.py
@@ -151,8 +151,8 @@ def train(rank, mlpf, train_loader, valid_loader, batch_size, optimizer, ssl_enc
             file = torch_geometric.loader.DataLoader([x for t in file for x in t], batch_size=batch_size)
 
         tf = 0
-        for i, batch in tqdm.tqdm(enumerate(file), total=len(file)):
-
+        for i, batch in enumerate(file):
+            print(batch.batch.shape, batch.batch.unique())
             if ssl_encoder is not None:
                 # seperate PF-elements
                 tracks, clusters = distinguish_PFelements(batch.to(rank))

--- a/mlpf/pyg/training.py
+++ b/mlpf/pyg/training.py
@@ -144,7 +144,7 @@ def train(rank, mlpf, train_loader, valid_loader, batch_size, optimizer, ssl_enc
         losses[loss] = 0.0
 
     tf_0, tf_f = time.time(), 0
-    for num, file in enumerate(file_loader):
+    for num, file in tqdm.tqdm(enumerate(file_loader), total=len(file_loader)):
         if "utils" in str(type(file_loader)):  # it must be converted to a pyg DataLoader if it's not (only needed for CMS)
             print(f"Time to load file {num+1}/{len(file_loader)} on rank {rank} is {round(time.time() - tf_0, 3)}s")
             tf_f = tf_f + (time.time() - tf_0)

--- a/mlpf/pyg_pipeline.py
+++ b/mlpf/pyg_pipeline.py
@@ -108,13 +108,16 @@ def train(rank, world_size, args, data, model, outpath):
     valid_dataset = torch.utils.data.Subset(
         data, np.arange(start=args.n_train + rank * hyper_valid, stop=args.n_train + (rank + 1) * hyper_valid)
     )
-
+    print("train_dataset=", len(train_dataset))
+    print("valid_dataset=", len(valid_dataset))
     if args.dataset == "CMS":  # construct file loaders first because we need to set num_workers>0 and pre_fetch factors>2
         file_loader_train = make_file_loaders(world_size, train_dataset)
         file_loader_valid = make_file_loaders(world_size, valid_dataset)
     else:  # construct pyg DataLoaders directly
         file_loader_train = torch_geometric.loader.DataLoader(train_dataset, args.bs)
         file_loader_valid = torch_geometric.loader.DataLoader(valid_dataset, args.bs)
+        print("file_loader_train=", len(file_loader_train))
+        print("file_loader_valid=", len(file_loader_valid))
 
     print("-----------------------------")
     if world_size > 1:

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ seaborn
 setGPU
 tensorflow
 tensorflow-addons
-tensorflow-datasets
+tensorflow-datasets==4.8.0
 tensorflow-estimator
 tensorflow-probability
 tensorflow-text

--- a/scripts/local_test_delphes_pipeline.sh
+++ b/scripts/local_test_delphes_pipeline.sh
@@ -2,16 +2,16 @@
 set -e
 export TFDS_DATA_DIR=`pwd`/tensorflow_datasets
 
-mkdir -p data/delphes_pf/pythia8_ttbar/raw
-mkdir -p data/delphes_pf/pythia8_qcd/val
+mkdir -p data/delphes_pf/pythia8_ttbar
+mkdir -p data/delphes_pf/pythia8_qcd
 
 #download a test input file (you can also download everything from Zenodo at 10.5281/zenodo.4559324)
 wget -q --no-check-certificate -nc https://zenodo.org/record/4559324/files/tev14_pythia8_ttbar_0_0.pkl.bz2
-mv tev14_pythia8_ttbar_0_0.pkl.bz2 data/delphes_pf/pythia8_ttbar/raw/
+mv tev14_pythia8_ttbar_0_0.pkl.bz2 data/delphes_pf/pythia8_ttbar/
 wget -q --no-check-certificate -nc https://zenodo.org/record/4559324/files/tev14_pythia8_qcd_10_0.pkl.bz2
-mv tev14_pythia8_qcd_10_0.pkl.bz2 data/delphes_pf/pythia8_qcd/val/
+mv tev14_pythia8_qcd_10_0.pkl.bz2 data/delphes_pf/pythia8_qcd/
 
-tfds build mlpf/heptfds/delphes_pf --download_dir data/
+tfds build mlpf/heptfds/delphes_pf --download_dir data/ --manual_dir data/delphes_pf
 
 #Run a simple training on a few events
 python mlpf/pipeline.py train --config parameters/delphes.yaml --nepochs 1 --ntrain 5 --ntest 5 --customize pipeline_test


### PR DESCRIPTION
Removed some duplication of code in the dataset prep between TF and pyg.

I think there's a bug in how the pyg loops over e.g. the CLIC dataset.
here: https://github.com/jpata/particleflow/blob/main/mlpf/pyg/training.py#L165-L172 there's currently a loop over files, and then a loop over events in the file

If I run the following, I expect the code should process 2 files per batch (200 events per batch).
```
python3 mlpf/pyg_pipeline.py --dataset CLIC --data_path data/clic_edm4hep/ --outpath experiments/pytorch_2 --bs 2 --n_train 1800 --n_valid 100 --n_test 100
```

You can see it's loading 1800 train files (`train_dataset= 1800`), and then batching them by 2 (`file_loader_train= 900`).
The outer loop has 900 steps, as expected.

**Problem**: The inner loop has 100 steps, this is not expected. For some reason it's only returning 2 events per batch in the inner loop (`torch.Size([278]) tensor([0, 1])`)?
```
Training over 3 epochs on the CLIC dataset.
train_dataset= 1800
valid_dataset= 100
file_loader_train= 900
file_loader_valid= 50
-----------------------------
Running training on cuda:0
Will launch a native training of MLPF.
---->Initiating a training run on rank cuda:0
  0%|                                                                       | 0/900 [00:00<?, ?it/s]
torch.Size([278]) tensor([0, 1])
torch.Size([396]) tensor([0, 1])
torch.Size([361]) tensor([0, 1])
torch.Size([329]) tensor([0, 1])
torch.Size([309]) tensor([0, 1])
```