### PR TITLE
add option to pad everything to a constant size

### DIFF
--- a/mlpf/tfmodel/model.py
+++ b/mlpf/tfmodel/model.py
@@ -1213,7 +1213,9 @@ class PFNetDense(tf.keras.Model):
     def call(self, inputs, training=False):
         Xorig = inputs
 
-        # tf.print(tf.shape(Xorig))
+        # zero_pad_fraction = tf.reduce_sum(
+        #     tf.cast(Xorig[:, :, 0]==0, dtype=tf.int32))/(tf.shape(Xorig)[0]*tf.shape(Xorig)[1])
+        # tf.print("PFNetDense.call Xorig=", tf.shape(Xorig), "zpf=", zero_pad_fraction)
 
         # normalize all features except the PFElement type (feature 0)
         # X = Xorig
@@ -1236,6 +1238,9 @@ class PFNetDense(tf.keras.Model):
             X = tf.cond(bins_to_pad_to > 1, lambda: tf.pad(X, pad_size), lambda: X)
         else:
             X = tf.pad(X, pad_size)
+
+        # zero_pad_fraction = tf.reduce_sum(tf.cast(X[:, :, 0]==0, dtype=tf.int32))/(tf.shape(X)[0]*tf.shape(X)[1])
+        # tf.print("PFNetDense.call X=", tf.shape(X), "zpf=", zero_pad_fraction)
 
         debugging_data = {}
 

--- a/mlpf/tfmodel/utils.py
+++ b/mlpf/tfmodel/utils.py
@@ -437,7 +437,7 @@ def load_and_interleave(
         # Multiply batch size by number of GPUs for MirroredStrategy
         if not config["setup"]["horovod_enabled"]:
             if num_batches_multiplier > 1:
-                bs = bs * num_batches_multiplier
+                bs = int(bs * num_batches_multiplier)
         logging.info("Batching {}:{} with padded_batch, batch_size={}".format(ds.name, ds.split, bs))
 
         # For padded_batch, either pad each batch of events to the largest event in each batch (if event_pad_size = None)

--- a/mlpf/tfmodel/utils.py
+++ b/mlpf/tfmodel/utils.py
@@ -437,7 +437,7 @@ def load_and_interleave(
         # Multiply batch size by number of GPUs for MirroredStrategy
         if not config["setup"]["horovod_enabled"]:
             if num_batches_multiplier > 1:
-                bs = int(bs * num_batches_multiplier)
+                bs = int(bs) * num_batches_multiplier
         logging.info("Batching {}:{} with padded_batch, batch_size={}".format(ds.name, ds.split, bs))
 
         # For padded_batch, either pad each batch of events to the largest event in each batch (if event_pad_size = None)

--- a/notebooks/clic/paper_plots_2023_ml_training.ipynb
+++ b/notebooks/clic/paper_plots_2023_ml_training.ipynb
@@ -605,31 +605,10 @@
    "source": [
     "df_h100 = import_scale_test(\"../../models/clic2023_20230802/gpu_scaling/scale_test_gnn_h100/scale_testV3_*/result.json\")\n",
     "df_mi250x = import_scale_test(\"../../models/clic2023_20230802/gpu_scaling/scale_test_gnn_mi250x_v3/*/result.json\")\n",
+    "df_mi250x_static = import_scale_test(\"../../models/clic2023_20230802/gpu_scaling/scale_test_gnn_mi250x_v4/*/result.json\")\n",
     "df_hpu = import_scale_test(\"../../models/clic2023_20230802/gpu_scaling/habana/*/result.json\")\n",
     "\n",
     "df_hpu_hvd = df_hpu[df_hpu[\"horovod_enabled\"] == True]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "df_mi250x"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "df_hpu"
    ]
   },
   {
@@ -648,6 +627,10 @@
     "    df_mi250x[\"epoch_times\"].values[0]/df_mi250x[\"epoch_times\"].values,\n",
     "    marker=\"s\", label=\"LUMI (MI250X)\")\n",
     "plt.plot(\n",
+    "    df_mi250x_static[\"num_gpus\"].values,\n",
+    "    df_mi250x_static[\"epoch_times\"].values[0]/df_mi250x_static[\"epoch_times\"].values,\n",
+    "    marker=\"s\", label=\"LUMI (MI250X), static batching\")\n",
+    "plt.plot(\n",
     "    df_hpu_hvd[\"num_gpus\"].values,\n",
     "    df_hpu_hvd[\"epoch_times\"].values[0]/df_hpu_hvd[\"epoch_times\"].values,\n",
     "    marker=\"s\", label=\"Voyager (Gaudi2)\")\n",
@@ -656,6 +639,33 @@
     "plt.ylabel(\"Speedup over single accelerator, T(1)/T(N)\")\n",
     "plt.savefig(\"./plots_mlpf_clic_2023/scale_test.pdf\")\n",
     "plt.savefig(\"./plots_mlpf_clic_2023/scale_test.png\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# plt.plot(\n",
+    "#     df_h100[\"num_gpus\"].values,\n",
+    "#     df_h100[\"epoch_times\"].values,\n",
+    "#     marker=\"o\", label=\"Jülich (H100)\")\n",
+    "plt.plot(\n",
+    "    df_mi250x[\"num_gpus\"].values,\n",
+    "    df_mi250x[\"epoch_times\"].values,\n",
+    "    marker=\"s\", label=\"LUMI (MI250X)\")\n",
+    "plt.plot(\n",
+    "    df_mi250x_static[\"num_gpus\"].values,\n",
+    "    df_mi250x_static[\"epoch_times\"].values,\n",
+    "    marker=\"s\", label=\"LUMI (MI250X), static batching\")\n",
+    "plt.plot(\n",
+    "    df_hpu_hvd[\"num_gpus\"].values,\n",
+    "    df_hpu_hvd[\"epoch_times\"].values,\n",
+    "    marker=\"s\", label=\"Voyager (Gaudi2)\")\n",
+    "plt.legend(loc=\"best\")\n",
+    "plt.xlabel(\"Accelerator processors, N\")\n",
+    "plt.ylabel(\"time per epoch, T(N) [s]\")"
    ]
   },
   {

--- a/notebooks/clic/paper_plots_2023_ml_training.ipynb
+++ b/notebooks/clic/paper_plots_2023_ml_training.ipynb
@@ -582,14 +582,17 @@
     "def import_scale_test(path=\"../../models/clic2023_20230802/gpu_scaling/scale_test_gnn_h100/scale_testV3_*/result.json\"):\n",
     "    num_gpus = []\n",
     "    epoch_times = []\n",
+    "    horovod_enabled = []\n",
     "    df = pandas.DataFrame()\n",
     "    for fn in glob.glob(path):\n",
     "        data = json.load(open(fn))\n",
     "        epoch_times.append(np.mean(data[\"wl-stats\"][\"epoch_times\"][1:]))\n",
     "        num_gpus.append(data[\"wl-stats\"][\"GPU\"])\n",
+    "        horovod_enabled.append(data[\"wl-stats\"].get(\"horovod_enabled\", False))\n",
     "\n",
     "    df[\"num_gpus\"] = num_gpus\n",
     "    df[\"epoch_times\"] = epoch_times\n",
+    "    df[\"horovod_enabled\"] = horovod_enabled\n",
     "    df = df.sort_values(\"num_gpus\")\n",
     "    return df"
    ]
@@ -601,8 +604,32 @@
    "outputs": [],
    "source": [
     "df_h100 = import_scale_test(\"../../models/clic2023_20230802/gpu_scaling/scale_test_gnn_h100/scale_testV3_*/result.json\")\n",
-    "df_mi250x = import_scale_test(\"../../models/clic2023_20230802/gpu_scaling/scale_test_gnn_mi250x/*/result.json\")\n",
-    "df_hpu = import_scale_test(\"../../models/clic2023_20230802/gpu_scaling/scale_test_habana/*/result.json\")"
+    "df_mi250x = import_scale_test(\"../../models/clic2023_20230802/gpu_scaling/scale_test_gnn_mi250x_v3/*/result.json\")\n",
+    "df_hpu = import_scale_test(\"../../models/clic2023_20230802/gpu_scaling/habana/*/result.json\")\n",
+    "\n",
+    "df_hpu_hvd = df_hpu[df_hpu[\"horovod_enabled\"] == True]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "df_mi250x"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "df_hpu"
    ]
   },
   {
@@ -615,18 +642,18 @@
     "plt.plot(\n",
     "    df_h100[\"num_gpus\"].values,\n",
     "    df_h100[\"epoch_times\"].values[0]/df_h100[\"epoch_times\"].values,\n",
-    "    marker=\"o\", label=\"H100\")\n",
+    "    marker=\"o\", label=\"Jülich (H100)\")\n",
     "plt.plot(\n",
     "    df_mi250x[\"num_gpus\"].values,\n",
     "    df_mi250x[\"epoch_times\"].values[0]/df_mi250x[\"epoch_times\"].values,\n",
-    "    marker=\"s\", label=\"MI250X\")\n",
+    "    marker=\"s\", label=\"LUMI (MI250X)\")\n",
     "plt.plot(\n",
-    "    df_hpu[\"num_gpus\"].values,\n",
-    "    df_hpu[\"epoch_times\"].values[0]/df_hpu[\"epoch_times\"].values,\n",
-    "    marker=\"s\", label=\"Habana\")\n",
+    "    df_hpu_hvd[\"num_gpus\"].values,\n",
+    "    df_hpu_hvd[\"epoch_times\"].values[0]/df_hpu_hvd[\"epoch_times\"].values,\n",
+    "    marker=\"s\", label=\"Voyager (Gaudi2)\")\n",
     "plt.legend(loc=\"best\")\n",
     "plt.xlabel(\"Accelerator processors, N\")\n",
-    "plt.ylabel(\"Speedup over single accelerator, T(N)/T(1)\")\n",
+    "plt.ylabel(\"Speedup over single accelerator, T(1)/T(N)\")\n",
     "plt.savefig(\"./plots_mlpf_clic_2023/scale_test.pdf\")\n",
     "plt.savefig(\"./plots_mlpf_clic_2023/scale_test.png\")"
    ]

--- a/parameters/clic-hits.yaml
+++ b/parameters/clic-hits.yaml
@@ -219,11 +219,13 @@ raytune:
 train_test_datasets:
   physical:
     batch_per_gpu: 1
+    event_pad_size: 12800 #need to verify this
     datasets:
       - clic_edm_ttbar_hits_pf
       - clic_edm_qq_hits_pf
   gun:
     batch_per_gpu: 5
+    event_pad_size: 2048 #need to verify this
     datasets:
       - clic_edm_single_kaon0l_hits_pf
       - clic_edm_single_pi_hits_pf

--- a/parameters/clic-test.yaml
+++ b/parameters/clic-test.yaml
@@ -60,6 +60,7 @@ setup:
   normalizer_cache: parameters/clic_normalizations
 
 batching:
+  # if enabled, use variable-size batching instead of the fixed-size batches configured per-sample in batch_per_gpu
   bucket_by_sequence_length: yes
   bucket_batch_sizes: auto
   batch_multiplier: 1
@@ -102,19 +103,6 @@ parameters:
     dist_activation: elu
     ffn_dist_num_layers: 3
     ffn_dist_hidden_dim: 64
-
-    # MPNN
-    #kernel:
-    # type: NodePairTrainableKernel
-    # activation: elu
-    #num_node_messages: 1
-    #node_message:
-    # type: NodeMessageLearnable
-    # output_dim: 64
-    # hidden_dim: 128
-    # num_layers: 2
-    # activation: elu
-    #activation: elu
 
     # GCN
     kernel:
@@ -217,6 +205,7 @@ raytune:
 train_test_datasets:
   physical:
     batch_per_gpu: 50
+    event_pad_size: -1
     datasets:
       - clic_edm_ttbar_pf
 

--- a/parameters/clic-test.yaml
+++ b/parameters/clic-test.yaml
@@ -61,7 +61,7 @@ setup:
 
 batching:
   # if enabled, use variable-size batching instead of the fixed-size batches configured per-sample in batch_per_gpu
-  bucket_by_sequence_length: yes
+  bucket_by_sequence_length: no
   bucket_batch_sizes: auto
   batch_multiplier: 1
 
@@ -205,7 +205,7 @@ raytune:
 train_test_datasets:
   physical:
     batch_per_gpu: 50
-    event_pad_size: -1
+    event_pad_size: 512
     datasets:
       - clic_edm_ttbar_pf
 

--- a/parameters/clic.yaml
+++ b/parameters/clic.yaml
@@ -60,8 +60,10 @@ setup:
   normalizer_cache: parameters/clic_normalizations
 
 batching:
-  # if enabled, use dynamic batching instead of the fixed-size batches configured in batch_per_gpu
+  # if enabled, use variable-size batching instead of the fixed-size batches configured per-sample in batch_per_gpu
   bucket_by_sequence_length: no
+  bucket_batch_sizes: auto
+  batch_multiplier: 1.0
 
 optimizer:
   adam:
@@ -101,19 +103,6 @@ parameters:
     dist_activation: elu
     ffn_dist_num_layers: 3
     ffn_dist_hidden_dim: 64
-
-    # MPNN
-    #kernel:
-    # type: NodePairTrainableKernel
-    # activation: elu
-    #num_node_messages: 1
-    #node_message:
-    # type: NodeMessageLearnable
-    # output_dim: 64
-    # hidden_dim: 128
-    # num_layers: 2
-    # activation: elu
-    #activation: elu
 
     # GCN
     kernel:
@@ -216,6 +205,7 @@ raytune:
 train_test_datasets:
   physical:
     batch_per_gpu: 50
+    event_pad_size: -1
     datasets:
       - clic_edm_ttbar_pf
       - clic_edm_qq_pf

--- a/parameters/cms-gen.yaml
+++ b/parameters/cms-gen.yaml
@@ -252,6 +252,7 @@ raytune:
 train_test_datasets:
   physical:
     batch_per_gpu: 1
+    event_pad_size: -1
     datasets:
       - cms_pf_ttbar
       - cms_pf_ztt
@@ -259,6 +260,7 @@ train_test_datasets:
       - cms_pf_qcd_high_pt
   gun:
     batch_per_gpu: 50
+    event_pad_size: -1
     datasets:
       - cms_pf_single_electron
       - cms_pf_single_gamma

--- a/parameters/delphes.yaml
+++ b/parameters/delphes.yaml
@@ -230,6 +230,7 @@ raytune:
 train_test_datasets:
   delphes:
     batch_per_gpu: 5
+    event_pad_size: -1
     datasets:
       - delphes_data_pf
 


### PR DESCRIPTION
One can now change `event_pad_size` in 
```
train_test_datasets:
  physical:
    batch_per_gpu: 50
    event_pad_size: -1
```

to make every batch of events be padded to the same size in terms of number of elements per event.

The previous/default behaviour, enabled when ` event_pad_size: -1`, is to pad events in each batch to the largest event in the batch.

This behaviour is enabled only when using static batching, i.e. `bucket_by_sequence_length: no`.

I'm running another scaling test on LUMI with the following config:
```diff
--- a/parameters/clic-test.yaml
+++ b/parameters/clic-test.yaml
@@ -61,7 +61,7 @@ setup:
 
 batching:
   # if enabled, use variable-size batching instead of the fixed-size batches configured per-sample in batch_per_gpu
-  bucket_by_sequence_length: yes
+  bucket_by_sequence_length: no
   bucket_batch_sizes: auto
   batch_multiplier: 1
 
@@ -205,7 +205,7 @@ raytune:
 train_test_datasets:
   physical:
     batch_per_gpu: 50
-    event_pad_size: -1
+    event_pad_size: 512
     datasets:
       - clic_edm_ttbar_pf
```