### PR TITLE
allow floating point batch multiplier

### DIFF
--- a/mlpf/pipeline.py
+++ b/mlpf/pipeline.py
@@ -146,7 +146,7 @@ def main():
 @click.option(
     "--batch-multiplier",
     help="batch size per device",
-    type=int,
+    type=float,
     default=None,
 )
 @click.option("--num-cpus", help="number of CPU threads to use", type=int, default=None)

--- a/mlpf/tfmodel/utils.py
+++ b/mlpf/tfmodel/utils.py
@@ -437,7 +437,8 @@ def load_and_interleave(
         # Multiply batch size by number of GPUs for MirroredStrategy
         if not config["setup"]["horovod_enabled"]:
             if num_batches_multiplier > 1:
-                bs = int(bs) * num_batches_multiplier
+                bs = bs * num_batches_multiplier
+        bs = int(bs)
         logging.info("Batching {}:{} with padded_batch, batch_size={}".format(ds.name, ds.split, bs))
 
         # For padded_batch, either pad each batch of events to the largest event in each batch (if event_pad_size = None)


### PR DESCRIPTION
To decrease effective batch size for all samples on a small GPU. 