### PR TITLE
pin matplotlib due to breaking changes in mpl 3.8.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ jupyter
 jupyter-book
 keras
 keras-tuner
-matplotlib
+matplotlib<=3.7.3
 mplhep
 networkx
 nevergrad


### PR DESCRIPTION
matplotlib 3.8.0, released just now, is incompatible with the current mplhep.
Reported to mplhep devs here: https://github.com/scikit-hep/mplhep/issues/441