### PR TITLE
making the 3d-padded models more efficient in pytorch

### DIFF
--- a/mlpf/pyg/PFDataset.py
+++ b/mlpf/pyg/PFDataset.py
@@ -68,6 +68,8 @@ class PFDataset:
             sampler=sampler,
             num_workers=num_workers,
             prefetch_factor=prefetch_factor,
+            pin_memory=True,
+            pin_memory_device="cuda:0",
         )
 
     def __len__(self):
@@ -134,14 +136,7 @@ class Collater:
         if not self.pad_3d:
             return ret
         else:
-            _, num_nodes = torch.unique(ret.batch, return_counts=True)
-            max_num_nodes = torch.max(num_nodes)
-            max_num_nodes_padded = ((max_num_nodes // self.pad_bin_size) + 1) * self.pad_bin_size
-
-            ret = {
-                k: torch_geometric.utils.to_dense_batch(getattr(ret, k), ret.batch, max_num_nodes=max_num_nodes_padded)
-                for k in elem_keys
-            }
+            ret = {k: torch_geometric.utils.to_dense_batch(getattr(ret, k), ret.batch) for k in elem_keys}
 
             ret["mask"] = ret["X"][1]
 

--- a/mlpf/pyg/PFDataset.py
+++ b/mlpf/pyg/PFDataset.py
@@ -69,7 +69,7 @@ class PFDataset:
             num_workers=num_workers,
             prefetch_factor=prefetch_factor,
             pin_memory=use_cuda,
-            pin_memory_device="cuda:{}".format(rank) if use_cuda else None,
+            pin_memory_device="cuda:{}".format(rank) if use_cuda else '',
         )
 
     def __len__(self):

--- a/mlpf/pyg/PFDataset.py
+++ b/mlpf/pyg/PFDataset.py
@@ -52,7 +52,7 @@ class PFDataset:
         sampler = torch.utils.data.distributed.DistributedSampler(self.ds)
         return sampler
 
-    def get_loader(self, batch_size, world_size, num_workers=0, prefetch_factor=None):
+    def get_loader(self, batch_size, world_size, rank, num_workers=0, prefetch_factor=None):
         if (num_workers > 0) and (prefetch_factor is None):
             prefetch_factor = 2  # default prefetch_factor when num_workers>0
 
@@ -69,7 +69,7 @@ class PFDataset:
             num_workers=num_workers,
             prefetch_factor=prefetch_factor,
             pin_memory=True,
-            pin_memory_device="cuda:0",
+            pin_memory_device="cuda:{}".format(rank),
         )
 
     def __len__(self):

--- a/mlpf/pyg/PFDataset.py
+++ b/mlpf/pyg/PFDataset.py
@@ -69,7 +69,7 @@ class PFDataset:
             num_workers=num_workers,
             prefetch_factor=prefetch_factor,
             pin_memory=use_cuda,
-            pin_memory_device="cuda:{}".format(rank) if use_cuda else '',
+            pin_memory_device="cuda:{}".format(rank) if use_cuda else "",
         )
 
     def __len__(self):

--- a/mlpf/pyg/PFDataset.py
+++ b/mlpf/pyg/PFDataset.py
@@ -52,7 +52,7 @@ class PFDataset:
         sampler = torch.utils.data.distributed.DistributedSampler(self.ds)
         return sampler
 
-    def get_loader(self, batch_size, world_size, rank, num_workers=0, prefetch_factor=None):
+    def get_loader(self, batch_size, world_size, rank, use_cuda=False, num_workers=0, prefetch_factor=None):
         if (num_workers > 0) and (prefetch_factor is None):
             prefetch_factor = 2  # default prefetch_factor when num_workers>0
 
@@ -68,8 +68,8 @@ class PFDataset:
             sampler=sampler,
             num_workers=num_workers,
             prefetch_factor=prefetch_factor,
-            pin_memory=True,
-            pin_memory_device="cuda:{}".format(rank),
+            pin_memory=use_cuda,
+            pin_memory_device="cuda:{}".format(rank) if use_cuda else None,
         )
 
     def __len__(self):

--- a/mlpf/pyg/gnn_lsh.py
+++ b/mlpf/pyg/gnn_lsh.py
@@ -239,8 +239,8 @@ def reverse_lsh(bins_split, points_binned_enc):
 
     ret = torch.zeros(batch_dim, n_points, n_features, device=points_binned_enc.device)
     for ibatch in range(batch_dim):
-        torch._assert(torch.min(bins_split_flat[ibatch]) >= 0, "reverse_lsh n_points min")
-        torch._assert(torch.max(bins_split_flat[ibatch]) < n_points, "reverse_lsh n_points max")
+        # torch._assert(torch.min(bins_split_flat[ibatch]) >= 0, "reverse_lsh n_points min")
+        # torch._assert(torch.max(bins_split_flat[ibatch]) < n_points, "reverse_lsh n_points max")
         ret[ibatch][bins_split_flat[ibatch]] = points_binned_enc_flat[ibatch]
     return ret
 

--- a/mlpf/pyg/gnn_lsh.py
+++ b/mlpf/pyg/gnn_lsh.py
@@ -138,7 +138,6 @@ class NodePairGaussianKernel(nn.Module):
         return dm
 
 
-@torch.compile
 def split_msk_and_msg(bins_split, cmul, x_msg, x_node, msk, n_bins, bin_size):
     bins_split_2 = torch.reshape(bins_split, (bins_split.shape[0], bins_split.shape[1] * bins_split.shape[2]))
 
@@ -222,7 +221,6 @@ class MessageBuildingLayerLSH(nn.Module):
         return bins_split, x_features_binned, dm, msk_f_binned
 
 
-@torch.compile
 def reverse_lsh(bins_split, points_binned_enc):
     shp = points_binned_enc.shape
     batch_dim = shp[0]

--- a/mlpf/pyg/gnn_lsh.py
+++ b/mlpf/pyg/gnn_lsh.py
@@ -33,11 +33,6 @@ def point_wise_feed_forward_network(
     return nn.Sequential(*layers)
 
 
-# @torch.compile
-def index_dim(a, b):
-    return a[b]
-
-
 def split_indices_to_bins_batch(cmul, nbins, bin_size, msk):
     a = torch.argmax(cmul, axis=-1)
 

--- a/mlpf/pyg/mlpf.py
+++ b/mlpf/pyg/mlpf.py
@@ -53,11 +53,19 @@ def ffn(input_dim, output_dim, width, act, dropout):
     )
 
 
-@torch.compile
-def unpad(data_padded, mask):
-    A = data_padded[mask]
+#@torch.compile
+def unpad(data_padded, mask, num_elems):
+    # A = data_padded[mask]
+    shp = data_padded.shape
+    A = torch.masked_select(data_padded, mask.unsqueeze(axis=-1).expand(shp[0], shp[1], shp[2])).reshape(num_elems, shp[2])
     return A
 
+#@torch.compile
+def unpad_all(embeddings, mask, n_elems, n_embed):
+    ret = []
+    for i in range(n_embed):
+        ret.append(unpad(embeddings[i], mask, n_elems))
+    return ret
 
 class MLPF(nn.Module):
     def __init__(
@@ -134,19 +142,18 @@ class MLPF(nn.Module):
         input_ = event.X.float()
         batch_idx = event.batch
 
+        _, num_nodes = torch.unique(batch_idx, return_counts=True)
+        max_num_nodes = torch.max(num_nodes)
+        max_num_nodes_padded = ((max_num_nodes // self.bin_size) + 1) * self.bin_size
+        input_padded, mask = torch_geometric.utils.to_dense_batch(
+            input_, batch_idx, max_num_nodes=max_num_nodes_padded
+        )
+
         embeddings_id, embeddings_reg = [], []
         if self.num_convs != 0:
-            embedding = self.nn0(input_)
-
-            if self.conv_type != "gravnet":
-                _, num_nodes = torch.unique(batch_idx, return_counts=True)
-                max_num_nodes = torch.max(num_nodes).cpu()
-                max_num_nodes_padded = ((max_num_nodes // self.bin_size) + 1) * self.bin_size
-                embedding, mask = torch_geometric.utils.to_dense_batch(
-                    embedding, batch_idx, max_num_nodes=max_num_nodes_padded
-                )
 
             if self.conv_type == "gravnet":
+                embedding = self.nn0(input_)
                 # perform a series of graph convolutions
                 for num, conv in enumerate(self.conv_id):
                     conv_input = embedding if num == 0 else embeddings_id[-1]
@@ -155,6 +162,7 @@ class MLPF(nn.Module):
                     conv_input = embedding if num == 0 else embeddings_reg[-1]
                     embeddings_reg.append(conv(conv_input, batch_idx))
             else:
+                embedding = self.nn0(input_padded)
                 for num, conv in enumerate(self.conv_id):
                     conv_input = embedding if num == 0 else embeddings_id[-1]
                     out_padded = conv(conv_input, ~mask)
@@ -164,16 +172,19 @@ class MLPF(nn.Module):
                     out_padded = conv(conv_input, ~mask)
                     embeddings_reg.append(out_padded)
 
-        if self.conv_type != "gravnet":
-            embeddings_id = [unpad(emb, mask) for emb in embeddings_id]
-            embeddings_reg = [unpad(emb, mask) for emb in embeddings_reg]
+        if self.conv_type == "gravnet":
+            embeddings_id = [torch_geometric.utils.to_dense_batch(
+                emb, batch_idx, max_num_nodes=max_num_nodes_padded
+            )[0] for emb in embeddings_id]
+            embeddings_reg = [torch_geometric.utils.to_dense_batch(
+                emb, batch_idx, max_num_nodes=max_num_nodes_padded
+            )[0] for emb in embeddings_reg]
 
-        # classification
-        embedding_id = torch.cat([input_] + embeddings_id, axis=-1)
+        embedding_id = torch.cat([input_padded] + embeddings_id, axis=-1)
         preds_id = self.nn_id(embedding_id)
 
         # regression
-        embedding_reg = torch.cat([input_] + embeddings_reg + [preds_id], axis=-1)
+        embedding_reg = torch.cat([input_padded] + embeddings_reg + [preds_id], axis=-1)
 
         # do some sanity checks on the PFElement input data
         # assert torch.all(torch.abs(input_[:, 3]) <= 1.0)  # sin_phi
@@ -183,10 +194,10 @@ class MLPF(nn.Module):
 
         # predict the 4-momentum, add it to the (pt, eta, sin phi, cos phi, E) of the input PFelement
         # the feature order is defined in fcc/postprocessing.py -> track_feature_order, cluster_feature_order
-        preds_pt = self.nn_pt(embedding_reg) + input_[:, 1:2]
-        preds_eta = self.nn_eta(embedding_reg) + input_[:, 2:3]
-        preds_phi = self.nn_phi(embedding_reg) + input_[:, 3:5]
-        preds_energy = self.nn_energy(embedding_reg) + input_[:, 5:6]
+        preds_pt = self.nn_pt(embedding_reg) + input_padded[..., 1:2]
+        preds_eta = self.nn_eta(embedding_reg) + input_padded[..., 2:3]
+        preds_phi = self.nn_phi(embedding_reg) + input_padded[..., 3:5]
+        preds_energy = self.nn_energy(embedding_reg) + input_padded[..., 5:6]
         preds_momentum = torch.cat([preds_pt, preds_eta, preds_phi, preds_energy], axis=-1)
         pred_charge = self.nn_charge(embedding_reg)
 

--- a/mlpf/pyg/training.py
+++ b/mlpf/pyg/training.py
@@ -261,7 +261,7 @@ def train_mlpf(rank, world_size, model, optimizer, train_loader, valid_loader, n
                 {"model_state_dict": model_state_dict, "optimizer_state_dict": optimizer.state_dict()},
                 # "{outdir}/weights-{epoch:02d}-{val_loss:.6f}.pth".format(
                 #   outdir=outdir, epoch=epoch+1, val_loss=losses_v["Total"]),
-                f"{outdir}/weights-best.pth",
+                f"{outdir}/best_weights.pth",
             )
 
         if hpo:

--- a/mlpf/pyg/training.py
+++ b/mlpf/pyg/training.py
@@ -130,7 +130,7 @@ class FocalLoss(nn.Module):
         return loss
 
 
-def train_and_valid(rank, world_size, model, optimizer, data_loader, is_train=True):
+def train_and_valid(rank, world_size, model, optimizer, data_loader, is_train):
     """
     Performs training over a given epoch. Will run a validation step every N_STEPS and after the last training batch.
     """
@@ -227,30 +227,12 @@ def train_mlpf(rank, world_size, model, optimizer, train_loader, valid_loader, n
                 activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA], record_shapes=True, with_stack=True
             ) as prof:
                 with record_function("model_train"):
-                    losses_t = train_and_valid(
-                        rank,
-                        world_size,
-                        model,
-                        optimizer,
-                        train_loader,
-                    )
+                    losses_t = train_and_valid(rank, world_size, model, optimizer, train_loader, True)
             prof.export_chrome_trace("trace.json")
         else:
-            losses_t = train_and_valid(
-                rank,
-                world_size,
-                model,
-                optimizer,
-                train_loader,
-            )
+            losses_t = train_and_valid(rank, world_size, model, optimizer, train_loader, True)
 
-        losses_v = train_and_valid(
-            rank,
-            world_size,
-            model,
-            optimizer,
-            valid_loader,
-        )
+        losses_v = train_and_valid(rank, world_size, model, optimizer, valid_loader, False)
 
         if hpo:
             # save model, optimizer and epoch number for HPO-supported checkpointing

--- a/mlpf/pyg/training.py
+++ b/mlpf/pyg/training.py
@@ -164,7 +164,7 @@ def train(
     model.train()
     for itrain, batch in tqdm.tqdm(enumerate(train_loader), total=len(train_loader)):
         istep += 1
-        batch = batch.to(rank)
+        batch = batch.to(rank, non_blocking=True)
 
         ygen = unpack_target(batch.ygen)
         ypred = model(batch)
@@ -217,7 +217,7 @@ def train(
                 valid_loss = {"Total": 0.0, "Classification": 0.0, "Regression": 0.0, "Charge": 0.0}
                 with torch.no_grad():
                     for ival, batch in tqdm.tqdm(enumerate(valid_loader), total=len(valid_loader)):
-                        batch = batch.to(rank)
+                        batch = batch.to(rank, non_blocking=True)
                         ygen = unpack_target(batch.ygen)
 
                         if world_size > 1:  # validation is only run on a single machine
@@ -339,7 +339,7 @@ def train_mlpf(rank, world_size, model, optimizer, train_loader, valid_loader, n
         # training step
         if epoch == -1:
             with profile(
-                activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA], record_shapes=False, with_stack=False
+                activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA], record_shapes=True, with_stack=True
             ) as prof:
                 with record_function("model_train"):
                     losses_t, losses_v, best_val_loss, stale_epochs = train(

--- a/mlpf/pyg/training.py
+++ b/mlpf/pyg/training.py
@@ -150,7 +150,15 @@ def train_and_valid(rank, world_size, model, optimizer, data_loader, is_train):
         batch = batch.to(rank, non_blocking=True)
 
         ygen = unpack_target(batch.ygen)
-        ypred = model(batch)
+
+        if is_train:
+            ypred = model(batch)
+        else:
+            if world_size > 1:  # validation is only run on a single machine
+                ypred = model.module(batch)
+            else:
+                ypred = model(batch)
+
         ypred = unpack_predictions(ypred)
 
         if is_train:

--- a/mlpf/pyg/training.py
+++ b/mlpf/pyg/training.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import matplotlib.pyplot as plt
 import numpy as np
 import torch
+import torch.distributed as dist
 import tqdm
 from torch import Tensor, nn
 from torch.nn import functional as F
@@ -166,6 +167,9 @@ def train_and_valid(rank, world_size, model, optimizer, data_loader, is_train):
 
         for loss_ in epoch_loss:
             epoch_loss[loss_] += loss[loss_].detach()
+
+    if world_size > 1:
+        dist.barrier()
 
     for loss_ in epoch_loss:
         epoch_loss[loss_] = epoch_loss[loss_].cpu().item() / len(data_loader)

--- a/mlpf/pyg/utils.py
+++ b/mlpf/pyg/utils.py
@@ -113,12 +113,12 @@ Y_FEATURES = ["cls_id", "charge", "pt", "eta", "sin_phi", "cos_phi", "energy", "
 
 def unpack_target(y):
     ret = {}
-    ret["cls_id"] = y[:, 0].long()
-    ret["charge"] = torch.clamp((y[:, 1] + 1).to(dtype=torch.float32), 0, 2)  # -1, 0, 1 -> 0, 1, 2
+    ret["cls_id"] = y[..., 0].long()
+    ret["charge"] = torch.clamp((y[..., 1] + 1).to(dtype=torch.float32), 0, 2)  # -1, 0, 1 -> 0, 1, 2
 
     for i, feat in enumerate(Y_FEATURES):
         if i >= 2:  # skip the cls and charge as they are defined above
-            ret[feat] = y[:, i].to(dtype=torch.float32)
+            ret[feat] = y[..., i].to(dtype=torch.float32)
     ret["phi"] = torch.atan2(ret["sin_phi"], ret["cos_phi"])
 
     # do some sanity checks
@@ -128,7 +128,7 @@ def unpack_target(y):
     assert torch.all(ret["energy"] >= 0.0)  # energy
 
     # note ~ momentum = ["pt", "eta", "sin_phi", "cos_phi", "energy"]
-    ret["momentum"] = y[:, 2:-1].to(dtype=torch.float32)
+    ret["momentum"] = y[..., 2:-1].to(dtype=torch.float32)
     ret["p4"] = torch.cat(
         [ret["pt"].unsqueeze(1), ret["eta"].unsqueeze(1), ret["phi"].unsqueeze(1), ret["energy"].unsqueeze(1)], axis=1
     )
@@ -153,7 +153,13 @@ def unpack_predictions(preds):
     ret["cls_id"] = torch.argmax(ret["cls_id_onehot"], axis=-1)
     ret["phi"] = torch.atan2(ret["sin_phi"], ret["cos_phi"])
     ret["p4"] = torch.cat(
-        [ret["pt"].unsqueeze(axis=-1), ret["eta"].unsqueeze(axis=-1), ret["phi"].unsqueeze(axis=-1), ret["energy"].unsqueeze(axis=-1)], axis=-1
+        [
+            ret["pt"].unsqueeze(axis=-1),
+            ret["eta"].unsqueeze(axis=-1),
+            ret["phi"].unsqueeze(axis=-1),
+            ret["energy"].unsqueeze(axis=-1),
+        ],
+        axis=-1,
     )
 
     return ret

--- a/mlpf/pyg/utils.py
+++ b/mlpf/pyg/utils.py
@@ -122,10 +122,10 @@ def unpack_target(y):
     ret["phi"] = torch.atan2(ret["sin_phi"], ret["cos_phi"])
 
     # do some sanity checks
-    assert torch.all(ret["pt"] >= 0.0)  # pt
-    assert torch.all(torch.abs(ret["sin_phi"]) <= 1.0)  # sin_phi
-    assert torch.all(torch.abs(ret["cos_phi"]) <= 1.0)  # cos_phi
-    assert torch.all(ret["energy"] >= 0.0)  # energy
+    # assert torch.all(ret["pt"] >= 0.0)  # pt
+    # assert torch.all(torch.abs(ret["sin_phi"]) <= 1.0)  # sin_phi
+    # assert torch.all(torch.abs(ret["cos_phi"]) <= 1.0)  # cos_phi
+    # assert torch.all(ret["energy"] >= 0.0)  # energy
 
     # note ~ momentum = ["pt", "eta", "sin_phi", "cos_phi", "energy"]
     ret["momentum"] = y[..., 2:-1].to(dtype=torch.float32)

--- a/mlpf/pyg/utils.py
+++ b/mlpf/pyg/utils.py
@@ -143,17 +143,17 @@ def unpack_predictions(preds):
     # ret["charge"] = torch.argmax(ret["charge"], axis=1, keepdim=True) - 1
 
     # unpacking
-    ret["pt"] = ret["momentum"][:, 0]
-    ret["eta"] = ret["momentum"][:, 1]
-    ret["sin_phi"] = ret["momentum"][:, 2]
-    ret["cos_phi"] = ret["momentum"][:, 3]
-    ret["energy"] = ret["momentum"][:, 4]
+    ret["pt"] = ret["momentum"][..., 0]
+    ret["eta"] = ret["momentum"][..., 1]
+    ret["sin_phi"] = ret["momentum"][..., 2]
+    ret["cos_phi"] = ret["momentum"][..., 3]
+    ret["energy"] = ret["momentum"][..., 4]
 
     # new variables
     ret["cls_id"] = torch.argmax(ret["cls_id_onehot"], axis=-1)
     ret["phi"] = torch.atan2(ret["sin_phi"], ret["cos_phi"])
     ret["p4"] = torch.cat(
-        [ret["pt"].unsqueeze(1), ret["eta"].unsqueeze(1), ret["phi"].unsqueeze(1), ret["energy"].unsqueeze(1)], axis=1
+        [ret["pt"].unsqueeze(axis=-1), ret["eta"].unsqueeze(axis=-1), ret["phi"].unsqueeze(axis=-1), ret["energy"].unsqueeze(axis=-1)], axis=-1
     )
 
     return ret

--- a/mlpf/pyg_pipeline.py
+++ b/mlpf/pyg_pipeline.py
@@ -137,7 +137,7 @@ def run(rank, world_size, config, args, outdir, logfile):
             )
             _logger.info(f"train_dataset: {ds}, {len(ds)}", color="blue")
 
-            train_loaders.append(ds.get_loader(batch_size, world_size, config["num_workers"], config["prefetch_factor"]))
+            train_loaders.append(ds.get_loader(batch_size, world_size, rank, num_workers=config["num_workers"], prefetch_factor=config["prefetch_factor"]))
 
         train_loader = InterleavedIterator(train_loaders)
 
@@ -159,7 +159,7 @@ def run(rank, world_size, config, args, outdir, logfile):
                 )
                 _logger.info(f"valid_dataset: {ds}, {len(ds)}", color="blue")
 
-                valid_loaders.append(ds.get_loader(batch_size, 1, config["num_workers"], config["prefetch_factor"]))
+                valid_loaders.append(ds.get_loader(batch_size, 1, rank, num_workers=config["num_workers"], prefetch_factor=config["prefetch_factor"]))
 
             valid_loader = InterleavedIterator(valid_loaders)
         else:
@@ -203,7 +203,7 @@ def run(rank, world_size, config, args, outdir, logfile):
             _logger.info(f"test_dataset: {ds}, {len(ds)}", color="blue")
 
             test_loaders[sample] = InterleavedIterator(
-                [ds.get_loader(batch_size, world_size, config["num_workers"], config["prefetch_factor"])]
+                [ds.get_loader(batch_size, world_size, 0, num_workers=config["num_workers"], prefetch_factor=config["prefetch_factor"])]
             )
 
             if not osp.isdir(f"{outdir}/preds/{sample}"):

--- a/mlpf/pyg_pipeline.py
+++ b/mlpf/pyg_pipeline.py
@@ -137,7 +137,15 @@ def run(rank, world_size, config, args, outdir, logfile):
             )
             _logger.info(f"train_dataset: {ds}, {len(ds)}", color="blue")
 
-            train_loaders.append(ds.get_loader(batch_size, world_size, rank, num_workers=config["num_workers"], prefetch_factor=config["prefetch_factor"]))
+            train_loaders.append(
+                ds.get_loader(
+                    batch_size,
+                    world_size,
+                    rank,
+                    num_workers=config["num_workers"],
+                    prefetch_factor=config["prefetch_factor"],
+                )
+            )
 
         train_loader = InterleavedIterator(train_loaders)
 
@@ -159,7 +167,11 @@ def run(rank, world_size, config, args, outdir, logfile):
                 )
                 _logger.info(f"valid_dataset: {ds}, {len(ds)}", color="blue")
 
-                valid_loaders.append(ds.get_loader(batch_size, 1, rank, num_workers=config["num_workers"], prefetch_factor=config["prefetch_factor"]))
+                valid_loaders.append(
+                    ds.get_loader(
+                        batch_size, 1, rank, num_workers=config["num_workers"], prefetch_factor=config["prefetch_factor"]
+                    )
+                )
 
             valid_loader = InterleavedIterator(valid_loaders)
         else:
@@ -203,7 +215,15 @@ def run(rank, world_size, config, args, outdir, logfile):
             _logger.info(f"test_dataset: {ds}, {len(ds)}", color="blue")
 
             test_loaders[sample] = InterleavedIterator(
-                [ds.get_loader(batch_size, world_size, 0, num_workers=config["num_workers"], prefetch_factor=config["prefetch_factor"])]
+                [
+                    ds.get_loader(
+                        batch_size,
+                        world_size,
+                        0,
+                        num_workers=config["num_workers"],
+                        prefetch_factor=config["prefetch_factor"],
+                    )
+                ]
             )
 
             if not osp.isdir(f"{outdir}/preds/{sample}"):

--- a/mlpf/pyg_pipeline.py
+++ b/mlpf/pyg_pipeline.py
@@ -69,6 +69,7 @@ def run(rank, world_size, config, args, outdir, logfile):
     """Demo function that will be passed to each gpu if (world_size > 1) else will run normally on the given device."""
 
     pad_3d = args.conv_type != "gravnet"
+    use_cuda = rank != "cpu"
 
     if world_size > 1:
         os.environ["MASTER_ADDR"] = "localhost"
@@ -142,6 +143,7 @@ def run(rank, world_size, config, args, outdir, logfile):
                     batch_size,
                     world_size,
                     rank,
+                    use_cuda=use_cuda,
                     num_workers=config["num_workers"],
                     prefetch_factor=config["prefetch_factor"],
                 )
@@ -169,7 +171,12 @@ def run(rank, world_size, config, args, outdir, logfile):
 
                 valid_loaders.append(
                     ds.get_loader(
-                        batch_size, 1, rank, num_workers=config["num_workers"], prefetch_factor=config["prefetch_factor"]
+                        batch_size,
+                        1,
+                        rank,
+                        use_cuda=use_cuda,
+                        num_workers=config["num_workers"],
+                        prefetch_factor=config["prefetch_factor"],
                     )
                 )
 
@@ -220,6 +227,7 @@ def run(rank, world_size, config, args, outdir, logfile):
                         batch_size,
                         world_size,
                         0,
+                        use_cuda=use_cuda,
                         num_workers=config["num_workers"],
                         prefetch_factor=config["prefetch_factor"],
                     )

--- a/mlpf/pyg_pipeline.py
+++ b/mlpf/pyg_pipeline.py
@@ -288,7 +288,7 @@ def device_agnostic_run(config, args, world_size, outdir):
     if config["gpus"]:
         assert (
             world_size <= torch.cuda.device_count()
-        ), f"--gpus is too high (specefied {world_size} gpus but only {torch.cuda.device_count()} gpus are available)"
+        ), f"--gpus is too high (specified {world_size} gpus but only {torch.cuda.device_count()} gpus are available)"
 
         torch.cuda.empty_cache()
         if world_size > 1:
@@ -314,6 +314,9 @@ def device_agnostic_run(config, args, world_size, outdir):
 
 
 def main():
+
+    # torch.multiprocessing.set_start_method('spawn')
+
     args = parser.parse_args()
     world_size = len(args.gpus.split(","))  # will be 1 for both cpu ("") and single-gpu ("0")
 

--- a/mlpf/pyg_pipeline.py
+++ b/mlpf/pyg_pipeline.py
@@ -52,7 +52,7 @@ parser.add_argument("--num-epochs", type=int, default=None, help="number of trai
 parser.add_argument("--patience", type=int, default=None, help="patience before early stopping")
 parser.add_argument("--lr", type=float, default=None, help="learning rate")
 parser.add_argument(
-    "--conv-type", type=str, default=None, help="which graph layer to use", choices=["gravnet", "attention", "gnn_lsh"]
+    "--conv-type", type=str, default="gravnet", help="which graph layer to use", choices=["gravnet", "attention", "gnn_lsh"]
 )
 parser.add_argument("--make-plots", action="store_true", default=None, help="make plots of the test predictions")
 parser.add_argument("--export-onnx", action="store_true", default=None, help="exports the model to onnx")

--- a/mlpf/pyg_pipeline.py
+++ b/mlpf/pyg_pipeline.py
@@ -153,7 +153,7 @@ def run(rank, world_size, config, args, outdir, logfile):
                     config["data_dir"],
                     f"{sample}:{version}",
                     "test",
-                    ["X", "ygen", "ycand"],
+                    ["X", "ygen"],
                     pad_3d=pad_3d,
                     num_samples=config["nvalid"],
                 )

--- a/mlpf/pyg_pipeline.py
+++ b/mlpf/pyg_pipeline.py
@@ -51,7 +51,7 @@ parser.add_argument("--test", action="store_true", default=None, help="tests the
 parser.add_argument("--num-epochs", type=int, default=None, help="number of training epochs")
 parser.add_argument("--patience", type=int, default=None, help="patience before early stopping")
 parser.add_argument("--lr", type=float, default=None, help="learning rate")
-parser.add_argument("--conv-type", type=str, default=None, help="choices are ['gnn_lsh', 'gravnet', 'attention']")
+parser.add_argument("--conv-type", type=str, default=None, help="which graph layer to use", choices=["gravnet", "attention", "gnn_lsh"])
 parser.add_argument("--make-plots", action="store_true", default=None, help="make plots of the test predictions")
 parser.add_argument("--export-onnx", action="store_true", default=None, help="exports the model to onnx")
 parser.add_argument("--ntrain", type=int, default=None, help="training samples to use, if None use entire dataset")

--- a/scripts/tallinn/a100/pytorch.sh
+++ b/scripts/tallinn/a100/pytorch.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#SBATCH --partition gpu
+#SBATCH --gres gpu:a100:1
+#SBATCH --mem-per-gpu 40G
+#SBATCH -o logs/slurm-%x-%j-%N.out
+
+IMG=/home/software/singularity/pytorch.simg
+cd ~/particleflow
+
+#TF training
+singularity exec -B /scratch/persistent --nv \
+    --env PYTHONPATH=hep_tfds \
+    $IMG python3.10 mlpf/pyg_pipeline.py --dataset cms --gpus 0 \
+    --data-dir /scratch/persistent/joosep/tensorflow_datasets --config parameters/pyg-cms.yaml \
+    --train --conv-type gnn_lsh --num-epochs 10 --gpu-batch-multiplier 10 --num-workers 1 --prefetch-factor 10 --ntrain 200

--- a/scripts/tallinn/rtx/pytorch.sh
+++ b/scripts/tallinn/rtx/pytorch.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#SBATCH --partition gpu
+#SBATCH --gres gpu:rtx:2
+#SBATCH --mem-per-gpu 40G
+#SBATCH -o logs/slurm-%x-%j-%N.out
+
+IMG=/home/software/singularity/pytorch.simg
+cd ~/particleflow
+
+#TF training
+singularity exec -B /scratch/persistent --nv \
+    --env PYTHONPATH=hep_tfds \
+    $IMG python3.10 mlpf/pyg_pipeline.py --dataset cms --gpus 0,1 \
+    --data-dir /scratch/persistent/joosep/tensorflow_datasets --config parameters/pyg-cms-small.yaml \
+    --train --conv-type gnn_lsh --num-epochs 10 --ntrain 1000 --ntest 1000 --gpu-batch-multiplier 1 --num-workers 1 --prefetch-factor 10


### PR DESCRIPTION
- The conversion of 3D-padded shapes `[batch, elems_per_event, features]` with a padding mask to pytorch geometric sparse `[all_elems, features]` was slow. Now this is not done any more when it's not needed
  - The geometric-style models (e.g. gravnet) use sparse data throughout, while the 3D-shape models (e.g. Attention, GNNLSH) use 3D-padded data throughout.
- use pin_memory in the DataLoader, which removes the host-to-device blocking call when doing `batch.to(...)`
- move the validation loop outside the train loop
  - possibly some follow-up with `world_size` is still required

After all changes, here's how the profiles look like on a single batch.

Gravnet, approx. 90ms / batch, including the backward pass:
![image](https://github.com/jpata/particleflow/assets/69717/4d95d8dd-6d59-4f03-8b28-0ce8fa255e31)

GNNLSH, approx. 125ms / batch, including the backward pass:
![image](https://github.com/jpata/particleflow/assets/69717/16c3f292-67f5-4cb1-af52-c2bf9a7db3a3)



Longer test on RTX2060S:
```
python3 mlpf/pyg_pipeline.py --config parameters/pyg-cms-small.yaml --dataset cms --gpus 0 --data-dir ~/tensorflow_datasets/ --train --conv-type gnn_lsh --num-epochs 5 --gpu-batch-multiplier 1 --num-workers 1 --prefetch-factor 10

before:
  2%|██▋            | 2656/160000 [06:16<6:11:37,  7.06it/s]

after:
  2%|██▊            | 2776/160000 [05:08<4:50:52,  9.01it/s]
```