### PR TITLE
Fix pytorch inference after #256

### DIFF
--- a/mlpf/pyg/mlpf.py
+++ b/mlpf/pyg/mlpf.py
@@ -73,11 +73,12 @@ class MLPF(nn.Module):
         self.dropout = dropout
         self.input_dim = input_dim
         self.num_convs = num_convs
+        
+        self.bin_size = 640
 
         # embedding of the inputs
         if num_convs != 0:
             self.nn0 = ffn(input_dim, embedding_dim, width, self.act, dropout)
-            self.bin_size = 640
             if self.conv_type == "gravnet":
                 self.conv_id = nn.ModuleList()
                 self.conv_reg = nn.ModuleList()

--- a/mlpf/pyg/mlpf.py
+++ b/mlpf/pyg/mlpf.py
@@ -73,7 +73,7 @@ class MLPF(nn.Module):
         self.dropout = dropout
         self.input_dim = input_dim
         self.num_convs = num_convs
-        
+
         self.bin_size = 640
 
         # embedding of the inputs

--- a/mlpf/pyg/training.py
+++ b/mlpf/pyg/training.py
@@ -258,7 +258,7 @@ def train_mlpf(rank, world_size, model, optimizer, train_loader, valid_loader, n
                     {"model_state_dict": model_state_dict, "optimizer_state_dict": optimizer.state_dict()},
                     # "{outdir}/weights-{epoch:02d}-{val_loss:.6f}.pth".format(
                     #   outdir=outdir, epoch=epoch+1, val_loss=losses_v["Total"]),
-                    f"{outdir}/weights-best.pth",
+                    f"{outdir}/best_weights.pth",
                 )
             else:
                 stale_epochs += 1

--- a/mlpf/pyg_pipeline.py
+++ b/mlpf/pyg_pipeline.py
@@ -50,7 +50,7 @@ parser.add_argument("--train", action="store_true", default=None, help="initiate
 parser.add_argument("--test", action="store_true", default=None, help="tests the model")
 parser.add_argument("--num-epochs", type=int, default=None, help="number of training epochs")
 parser.add_argument("--patience", type=int, default=None, help="patience before early stopping")
-parser.add_argument("--lr", type=float, default=None, help="learning rate")
+parser.add_argument("--lr", type=float, default=0.001, help="learning rate")
 parser.add_argument(
     "--conv-type", type=str, default="gravnet", help="which graph layer to use", choices=["gravnet", "attention", "gnn_lsh"]
 )
@@ -216,7 +216,7 @@ def run(rank, world_size, config, args, outdir, logfile):
                 f"{sample}:{version}",
                 "test",
                 ["X", "ygen", "ycand"],
-                pad_3d=pad_3d,
+                pad_3d=False, #in inference, use sparse dataset
                 num_samples=config["ntest"],
             )
             _logger.info(f"test_dataset: {ds}, {len(ds)}", color="blue")

--- a/mlpf/pyg_pipeline.py
+++ b/mlpf/pyg_pipeline.py
@@ -216,7 +216,7 @@ def run(rank, world_size, config, args, outdir, logfile):
                 f"{sample}:{version}",
                 "test",
                 ["X", "ygen", "ycand"],
-                pad_3d=False, #in inference, use sparse dataset
+                pad_3d=False,  # in inference, use sparse dataset
                 num_samples=config["ntest"],
             )
             _logger.info(f"test_dataset: {ds}, {len(ds)}", color="blue")

--- a/mlpf/pyg_pipeline.py
+++ b/mlpf/pyg_pipeline.py
@@ -50,7 +50,7 @@ parser.add_argument("--train", action="store_true", default=None, help="initiate
 parser.add_argument("--test", action="store_true", default=None, help="tests the model")
 parser.add_argument("--num-epochs", type=int, default=None, help="number of training epochs")
 parser.add_argument("--patience", type=int, default=None, help="patience before early stopping")
-parser.add_argument("--lr", type=float, default=0.001, help="learning rate")
+parser.add_argument("--lr", type=float, default=None, help="learning rate")
 parser.add_argument(
     "--conv-type", type=str, default="gravnet", help="which graph layer to use", choices=["gravnet", "attention", "gnn_lsh"]
 )
@@ -86,7 +86,7 @@ def run(rank, world_size, config, args, outdir, logfile):
             model_kwargs = pkl.load(f)
 
         model = MLPF(**model_kwargs)
-        optimizer = torch.optim.AdamW(model.parameters(), lr=args.lr)
+        optimizer = torch.optim.AdamW(model.parameters(), lr=config["lr"])
 
         checkpoint = torch.load(f"{outdir}/best_weights.pth", map_location=torch.device(rank))
 

--- a/mlpf/tfmodel/model.py
+++ b/mlpf/tfmodel/model.py
@@ -258,8 +258,9 @@ class InputEncodingCMS(tf.keras.layers.Layer):
             dtype=X.dtype,
         )
 
-        tf.debugging.assert_greater_equal(X[:, :, 1], 0.0, message="pt", summarize=100)
-        tf.debugging.assert_greater_equal(X[:, :, 5], 0.0, message="energy", summarize=100)
+        if DEBUGGING:
+            tf.debugging.assert_greater_equal(X[:, :, 1], 0.0, message="pt", summarize=100)
+            tf.debugging.assert_greater_equal(X[:, :, 5], 0.0, message="energy", summarize=100)
         Xpt = tf.expand_dims(tf.math.log(X[:, :, 1] + 1.0), axis=-1)
         Xe = tf.expand_dims(tf.math.log(X[:, :, 5] + 1.0), axis=-1)
 

--- a/parameters/pyg-cms-small.yaml
+++ b/parameters/pyg-cms-small.yaml
@@ -56,45 +56,6 @@ valid_dataset:
 
 test_dataset:
   cms:
-    cms_pf_ttbar:
-      version: 1.6.0
-      batch_size: 1
-    cms_pf_qcd:
-      version: 1.6.0
-      batch_size: 1
-    cms_pf_ztt:
-      version: 1.6.0
-      batch_size: 1
     cms_pf_qcd_high_pt:
       version: 1.6.0
-      batch_size: 1
-    cms_pf_sms_t1tttt:
-      version: 1.6.0
-      batch_size: 1
-    cms_pf_single_electron:
-      version: 1.6.0
-      batch_size: 20
-    cms_pf_single_gamma:
-      version: 1.6.0
-      batch_size: 20
-    cms_pf_single_pi0:
-      version: 1.6.0
-      batch_size: 20
-    cms_pf_single_neutron:
-      version: 1.6.0
-      batch_size: 20
-    cms_pf_single_pi:
-      version: 1.6.0
-      batch_size: 20
-    cms_pf_single_tau:
-      version: 1.6.0
-      batch_size: 20
-    cms_pf_single_mu:
-      version: 1.6.0
-      batch_size: 20
-    cms_pf_single_proton:
-      version: 1.6.0
-      batch_size: 20
-    cms_pf_multi_particle_gun:
-      version: 1.6.0
-      batch_size: 5
+      batch_size: 10

--- a/scripts/tallinn/rtx/pytorch.sh
+++ b/scripts/tallinn/rtx/pytorch.sh
@@ -12,4 +12,4 @@ singularity exec -B /scratch/persistent --nv \
     --env PYTHONPATH=hep_tfds \
     $IMG python3.10 mlpf/pyg_pipeline.py --dataset cms --gpus 0,1 \
     --data-dir /scratch/persistent/joosep/tensorflow_datasets --config parameters/pyg-cms-small.yaml \
-    --train --conv-type gnn_lsh --num-epochs 10 --ntrain 500 --ntest 500 --gpu-batch-multiplier 1
+    --train --conv-type gnn_lsh --num-epochs 10 --ntrain 500 --ntest 500 --gpu-batch-multiplier 1 --num-workers 1 --prefetch-factor 10

--- a/scripts/tallinn/rtx/pytorch.sh
+++ b/scripts/tallinn/rtx/pytorch.sh
@@ -12,4 +12,4 @@ singularity exec -B /scratch/persistent --nv \
     --env PYTHONPATH=hep_tfds \
     $IMG python3.10 mlpf/pyg_pipeline.py --dataset cms --gpus 0,1 \
     --data-dir /scratch/persistent/joosep/tensorflow_datasets --config parameters/pyg-cms-small.yaml \
-    --train --conv-type gnn_lsh --num-epochs 10 --ntrain 1000 --ntest 1000 --gpu-batch-multiplier 1 --num-workers 1 --prefetch-factor 10
+    --train --conv-type gnn_lsh --num-epochs 10 --ntrain 500 --ntest 500 --gpu-batch-multiplier 1


### PR DESCRIPTION
Residual fixes after https://github.com/jpata/particleflow/pull/256.

Training the gnn_lsh for three epochs on pyg-cms-small.yaml I get the following performance: 
![jet_res](https://github.com/jpata/particleflow/assets/69717/91dccd7c-6239-4f78-85f6-69d272952a99)
![met_res](https://github.com/jpata/particleflow/assets/69717/94b9ec1e-fe45-49f9-85e6-762c7955682b)
