### PR TITLE
Implementing configurable checkpointing.

### DIFF
--- a/mlpf/pyg_pipeline.py
+++ b/mlpf/pyg_pipeline.py
@@ -1,7 +1,7 @@
 """
 Developing a PyTorch Geometric supervised training of MLPF using DistributedDataParallel.
 
-Author: Farouk Mokhtar
+Authors: Farouk Mokhtar, Joosep Pata, Eric Wulff
 """
 
 import argparse

--- a/mlpf/pyg_pipeline.py
+++ b/mlpf/pyg_pipeline.py
@@ -23,7 +23,7 @@ from pyg.logger import _configLogger, _logger
 from pyg.mlpf import MLPF
 from pyg.PFDataset import InterleavedIterator, PFDataset
 from pyg.training import train_mlpf
-from pyg.utils import CLASS_LABELS, X_FEATURES, save_HPs
+from pyg.utils import CLASS_LABELS, X_FEATURES, save_HPs, load_checkpoint
 from utils import create_experiment_dir
 
 
@@ -52,13 +52,14 @@ parser.add_argument("--num-epochs", type=int, default=None, help="number of trai
 parser.add_argument("--patience", type=int, default=None, help="patience before early stopping")
 parser.add_argument("--lr", type=float, default=None, help="learning rate")
 parser.add_argument(
-    "--conv-type", type=str, default="gravnet", help="which graph layer to use", choices=["gravnet", "attention", "gnn_lsh"]
+    "--conv-type", type=str, default=None, help="which graph layer to use", choices=["gravnet", "attention", "gnn_lsh"]
 )
 parser.add_argument("--make-plots", action="store_true", default=None, help="make plots of the test predictions")
 parser.add_argument("--export-onnx", action="store_true", default=None, help="exports the model to onnx")
 parser.add_argument("--ntrain", type=int, default=None, help="training samples to use, if None use entire dataset")
 parser.add_argument("--ntest", type=int, default=None, help="training samples to use, if None use entire dataset")
-parser.add_argument("--nvalid", type=int, default=500, help="validation samples to use, default will use 500 events")
+parser.add_argument("--nvalid", type=int, default=None, help="validation samples to use")
+parser.add_argument("--checkpoint-freq", type=int, default=None, help="epoch frequency for checkpointing")
 parser.add_argument("--hpo", type=str, default=None, help="perform hyperparameter optimization, name of HPO experiment")
 parser.add_argument("--local", action="store_true", default=None, help="perform HPO locally, without a Ray cluster")
 parser.add_argument("--ray-cpus", type=int, default=None, help="CPUs per trial for HPO")
@@ -68,7 +69,7 @@ parser.add_argument("--ray-gpus", type=int, default=None, help="GPUs per trial f
 def run(rank, world_size, config, args, outdir, logfile):
     """Demo function that will be passed to each gpu if (world_size > 1) else will run normally on the given device."""
 
-    pad_3d = args.conv_type != "gravnet"
+    pad_3d = config["conv_type"] != "gravnet"
     use_cuda = rank != "cpu"
 
     if world_size > 1:
@@ -89,12 +90,7 @@ def run(rank, world_size, config, args, outdir, logfile):
         optimizer = torch.optim.AdamW(model.parameters(), lr=config["lr"])
 
         checkpoint = torch.load(f"{outdir}/best_weights.pth", map_location=torch.device(rank))
-
-        if isinstance(model, torch.nn.parallel.DistributedDataParallel):
-            model.module.load_state_dict(checkpoint["model_state_dict"])
-        else:
-            model.load_state_dict(checkpoint["model_state_dict"])
-        optimizer.load_state_dict(checkpoint["optimizer_state_dict"])
+        model, optimizer = load_checkpoint(checkpoint, model, optimizer)
 
         if (rank == 0) or (rank == "cpu"):
             _logger.info(f"Loaded model weights from {outdir}/best_weights.pth")
@@ -190,6 +186,7 @@ def run(rank, world_size, config, args, outdir, logfile):
             config["patience"],
             outdir,
             hpo=True if args.hpo is not None else False,
+            checkpoint_freq=config["checkpoint_freq"],
         )
 
     if args.test:
@@ -234,12 +231,7 @@ def run(rank, world_size, config, args, outdir, logfile):
                     os.system(f"mkdir -p {outdir}/preds/{sample}")
 
         checkpoint = torch.load(f"{outdir}/best_weights.pth", map_location=torch.device(rank))
-
-        if isinstance(model, torch.nn.parallel.DistributedDataParallel):
-            model.module.load_state_dict(checkpoint["model_state_dict"])
-        else:
-            model.load_state_dict(checkpoint["model_state_dict"])
-        optimizer.load_state_dict(checkpoint["optimizer_state_dict"])
+        model, optimizer = load_checkpoint(checkpoint, model, optimizer)
 
         for sample in test_loaders:
             _logger.info(f"Running predictions on {sample}")

--- a/parameters/pyg-clic.yaml
+++ b/parameters/pyg-clic.yaml
@@ -11,8 +11,10 @@ lr: 0.0001
 conv_type: gnn_lsh
 ntrain:
 ntest:
+nvalid: 500
 num_workers: 0
 prefetch_factor:
+checkpoint_freq:
 
 model:
   gnn_lsh:
@@ -40,7 +42,7 @@ model:
     dropout: 0.0
 
 raytune:
-  local_dir: /mnt/ceph/users/ewulff/ray_results/  # Note: please specify an absolute path
+  local_dir:  # Note: please specify an absolute path
   sched:  # asha, hyperband
   search_alg:  # bayes, bohb, hyperopt, nevergrad, scikit
   default_metric: "val_loss"

--- a/parameters/pyg-cms-small.yaml
+++ b/parameters/pyg-cms-small.yaml
@@ -11,8 +11,10 @@ lr: 0.0001
 conv_type: gnn_lsh
 ntrain:
 ntest:
+nvalid: 500
 num_workers: 0
 prefetch_factor:
+checkpoint_freq:
 
 model:
   gnn_lsh:

--- a/parameters/pyg-cms-test-qcdhighpt.yaml
+++ b/parameters/pyg-cms-test-qcdhighpt.yaml
@@ -11,8 +11,10 @@ lr: 0.0001
 conv_type: gnn_lsh
 ntrain:
 ntest:
+nvalid: 500
 num_workers: 0
 prefetch_factor:
+checkpoint_freq:
 
 model:
   gnn_lsh:

--- a/parameters/pyg-cms.yaml
+++ b/parameters/pyg-cms.yaml
@@ -11,8 +11,10 @@ lr: 0.0001
 conv_type: gnn_lsh
 ntrain:
 ntest:
+nvalid: 500
 num_workers: 0
 prefetch_factor:
+checkpoint_freq: 2
 
 model:
   gnn_lsh:
@@ -40,7 +42,7 @@ model:
     dropout: 0.0
 
 raytune:
-  local_dir: /mnt/ceph/users/ewulff/ray_results/  # Note: please specify an absolute path
+  local_dir:  # Note: please specify an absolute path
   sched:  # asha, hyperband
   search_alg:  # bayes, bohb, hyperopt, nevergrad, scikit
   default_metric: "val_loss"

--- a/parameters/pyg-delphes.yaml
+++ b/parameters/pyg-delphes.yaml
@@ -11,8 +11,10 @@ lr: 0.0001
 conv_type: gnn_lsh
 ntrain:
 ntest:
+nvalid: 500
 num_workers: 0
 prefetch_factor:
+checkpoint_freq:
 
 model:
   gnn_lsh:

--- a/parameters/pyg-workflow-test.yaml
+++ b/parameters/pyg-workflow-test.yaml
@@ -11,8 +11,10 @@ lr: 0.0001
 conv_type: gravnet
 ntrain:
 ntest:
+nvalid: 500
 num_workers: 0
 prefetch_factor:
+checkpoint_freq:
 
 model:
   gnn_lsh:

--- a/scripts/flatiron/pt_raytune_1GPUperTrial.sh
+++ b/scripts/flatiron/pt_raytune_1GPUperTrial.sh
@@ -82,7 +82,8 @@ python3 -u mlpf/pyg_pipeline.py --train \
     --ray-cpus $((SLURM_CPUS_PER_TASK/4)) \
     --ray-gpus 1 \
     --gpus "0" \
-    --ntrain 1000 \
-    --ntest 1000
+    --ntrain 100 \
+    --ntest 100 \
+    --num-workers 0
 
 exit

--- a/scripts/flatiron/pt_train_4GPUs.slurm
+++ b/scripts/flatiron/pt_train_4GPUs.slurm
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Walltime limit
-#SBATCH -t 1:00:00
+#SBATCH -t 2:00:00
 #SBATCH -N 1
 #SBATCH --exclusive
 #SBATCH --tasks-per-node=1
@@ -36,11 +36,13 @@ CUDA_VISIBLE_DEVICES=0,1,2,3 python3 -u mlpf/pyg_pipeline.py --train \
     --config $1 \
     --prefix $2 \
     --gpus "0" \
-    --num-epochs 3 \
+    --num-epochs 4 \
     --lr 0.0001 \
     --conv-type gnn_lsh \
-    --ntrain 400 \
-    --ntest 400 \
-    --num-workers 1
+    --ntrain 100 \
+    --ntest 100 \
+    --nvalid 100 \
+    --gpu-batch-multiplier 16 \
+    --num-workers 0
 
 echo 'Training done.'


### PR DESCRIPTION
- Checkpoint the PyTorch training at regular frequencies given by `checkpoint_freq`, specified in the config or on the command line with `--checkpoint-freq`.
- Progress messages now show `train` or `valid` instead of `train=True` or `train=False`.
- Separated out saving and loading of checkpoints into functions, saving the model, the optimizer (optional) and a `dict` named `extra_state` that can contain any additional information (optional). `extra_state` currently only contains the epoch number when the checkpoint was saved.