### PR TITLE
Learning rate schedules and Mamba layer

### DIFF
--- a/mlpf/pyg/mlpf.py
+++ b/mlpf/pyg/mlpf.py
@@ -59,11 +59,18 @@ class MLPF(nn.Module):
         embedding_dim=128,
         width=128,
         num_convs=2,
+        dropout=0.0,
+        # gravnet specific parameters
         k=32,
         propagate_dimensions=32,
         space_dimensions=4,
-        dropout=0.0,
         conv_type="gravnet",
+        # gnn-lsh specific parameters
+        max_num_bins=200,
+        distance_dim=128,
+        layernorm=True,
+        num_node_messages=2,
+        ffn_dist_hidden_dim=128,
     ):
         super(MLPF, self).__init__()
 
@@ -98,12 +105,12 @@ class MLPF(nn.Module):
                     gnn_conf = {
                         "inout_dim": embedding_dim,
                         "bin_size": self.bin_size,
-                        "max_num_bins": 200,
-                        "distance_dim": 128,
-                        "layernorm": True,
-                        "num_node_messages": 2,
+                        "max_num_bins": max_num_bins,
+                        "distance_dim": distance_dim,
+                        "layernorm": layernorm,
+                        "num_node_messages": num_node_messages,
                         "dropout": dropout,
-                        "ffn_dist_hidden_dim": 128,
+                        "ffn_dist_hidden_dim": ffn_dist_hidden_dim,
                     }
                     self.conv_id.append(CombinedGraphLayer(**gnn_conf))
                     self.conv_reg.append(CombinedGraphLayer(**gnn_conf))

--- a/mlpf/pyg/mlpf.py
+++ b/mlpf/pyg/mlpf.py
@@ -60,28 +60,40 @@ class MLPF(nn.Module):
         width=128,
         num_convs=2,
         dropout=0.0,
+        activation="elu",
         # gravnet specific parameters
         k=32,
         propagate_dimensions=32,
         space_dimensions=4,
         conv_type="gravnet",
         # gnn-lsh specific parameters
+        bin_size=640,
         max_num_bins=200,
         distance_dim=128,
         layernorm=True,
         num_node_messages=2,
         ffn_dist_hidden_dim=128,
+        # self-attention specific parameters
+        num_heads=2,
     ):
         super(MLPF, self).__init__()
 
         self.conv_type = conv_type
 
-        self.act = nn.ELU
+        if activation == "elu":
+            self.act = nn.ELU
+        elif activation == "relu":
+            self.act = nn.ReLU
+        elif activation == "relu6":
+            self.act = nn.ReLU6
+        elif activation == "leakyrelu":
+            self.act = nn.LeakyReLU
+
         self.dropout = dropout
         self.input_dim = input_dim
         self.num_convs = num_convs
 
-        self.bin_size = 640
+        self.bin_size = bin_size
 
         # embedding of the inputs
         if num_convs != 0:
@@ -96,8 +108,8 @@ class MLPF(nn.Module):
                 self.conv_id = nn.ModuleList()
                 self.conv_reg = nn.ModuleList()
                 for i in range(num_convs):
-                    self.conv_id.append(SelfAttentionLayer(embedding_dim))
-                    self.conv_reg.append(SelfAttentionLayer(embedding_dim))
+                    self.conv_id.append(SelfAttentionLayer(embedding_dim, num_heads, width, dropout))
+                    self.conv_reg.append(SelfAttentionLayer(embedding_dim, num_heads, width, dropout))
             elif self.conv_type == "gnn_lsh":
                 self.conv_id = nn.ModuleList()
                 self.conv_reg = nn.ModuleList()

--- a/mlpf/pyg/mlpf.py
+++ b/mlpf/pyg/mlpf.py
@@ -62,7 +62,7 @@ class MLPF(nn.Module):
         k=32,
         propagate_dimensions=32,
         space_dimensions=4,
-        dropout=0.4,
+        dropout=0.0,
         conv_type="gravnet",
     ):
         super(MLPF, self).__init__()
@@ -102,7 +102,7 @@ class MLPF(nn.Module):
                         "distance_dim": 128,
                         "layernorm": True,
                         "num_node_messages": 2,
-                        "dropout": 0.0,
+                        "dropout": dropout,
                         "ffn_dist_hidden_dim": 128,
                     }
                     self.conv_id.append(CombinedGraphLayer(**gnn_conf))
@@ -123,7 +123,6 @@ class MLPF(nn.Module):
         self.nn_charge = ffn(decoding_dim + num_classes, 3, width, self.act, dropout)
 
     def forward(self, X_features, batch_or_mask):
-
         embeddings_id, embeddings_reg = [], []
         if self.num_convs != 0:
             embedding = self.nn0(X_features)

--- a/mlpf/pyg/training.py
+++ b/mlpf/pyg/training.py
@@ -504,7 +504,11 @@ def run(rank, world_size, config, args, outdir, logfile):
             comet_experiment.set_model_graph(model)
             comet_experiment.log_code("mlpf/pyg/training.py")
             comet_experiment.log_code("mlpf/pyg_pipeline.py")
-            comet_experiment.log_code(args.config)
+            # save overridden config then log to comet
+            config_filename = "overridden_config.yaml"
+            with open((Path(outdir) / config_filename), "w") as file:
+                yaml.dump(config, file)
+            comet_experiment.log_code(str(Path(outdir) / config_filename))
         else:
             comet_experiment = None
 
@@ -727,7 +731,11 @@ def train_ray_trial(config, args, outdir=None):
         comet_experiment.log_code(str(Path(outdir).parent.parent / "mlpf/pyg/training.py"))
         comet_experiment.log_code(str(Path(outdir).parent.parent / "mlpf/pyg_pipeline.py"))
         comet_experiment.log_code(str(Path(outdir).parent.parent / "mlpf/raytune/pt_search_space.py"))
-        comet_experiment.log_code(args.config)
+        # save overridden config then log to comet
+        config_filename = "overridden_config.yaml"
+        with open((Path(outdir) / config_filename), "w") as file:
+            yaml.dump(config, file)
+        comet_experiment.log_code(str(Path(outdir) / config_filename))
     else:
         comet_experiment = None
 

--- a/mlpf/pyg/training.py
+++ b/mlpf/pyg/training.py
@@ -499,7 +499,7 @@ def run(rank, world_size, config, args, outdir, logfile):
             comet_experiment = create_comet_experiment(
                 config["comet_name"], comet_offline=config["comet_offline"], outdir=outdir
             )
-            comet_experiment.set_name(f"rank_{rank}")
+            comet_experiment.set_name(f"rank_{rank}_{Path(outdir).name}")
             comet_experiment.log_parameter("run_id", Path(outdir).name)
             comet_experiment.log_parameter("world_size", world_size)
             comet_experiment.log_parameter("rank", rank)
@@ -729,7 +729,7 @@ def train_ray_trial(config, args, outdir=None):
         comet_experiment = create_comet_experiment(
             config["comet_name"], comet_offline=config["comet_offline"], outdir=outdir
         )
-        comet_experiment.set_name(f"world_rank_{world_rank}")
+        comet_experiment.set_name(f"world_rank_{world_rank}_{Path(outdir).name}")
         comet_experiment.log_parameter("run_id", Path(outdir).name)
         comet_experiment.log_parameter("world_size", world_size)
         comet_experiment.log_parameter("rank", rank)

--- a/mlpf/pyg/training.py
+++ b/mlpf/pyg/training.py
@@ -9,6 +9,7 @@ import logging
 import shutil
 from datetime import datetime
 import tqdm
+import yaml
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -162,7 +163,7 @@ def train_and_valid(
     """
 
     train_or_valid = "train" if is_train else "valid"
-    _logger.info(f"Initiating a {train_or_valid} run on device rank={rank}", color="red")
+    _logger.info(f"Initiating epoch #{epoch} {train_or_valid} run on device rank={rank}", color="red")
 
     # this one will keep accumulating `train_loss` and then return the average
     epoch_loss = {"Total": 0.0, "Classification": 0.0, "Regression": 0.0, "Charge": 0.0}
@@ -176,7 +177,9 @@ def train_and_valid(
     if (world_size > 1) and (rank != 0):
         iterator = enumerate(data_loader)
     else:
-        iterator = tqdm.tqdm(enumerate(data_loader), total=len(data_loader), desc=f"{train_or_valid} loop on rank={rank}")
+        iterator = tqdm.tqdm(
+            enumerate(data_loader), total=len(data_loader), desc=f"Epoch {epoch} {train_or_valid} loop on rank={rank}"
+        )
 
     for itrain, batch in iterator:
         batch = batch.to(rank, non_blocking=True)
@@ -207,7 +210,7 @@ def train_and_valid(
         for loss_ in epoch_loss:
             epoch_loss[loss_] += loss[loss_].detach()
 
-        if comet_experiment:
+        if comet_experiment and is_train:
             if itrain % comet_step_freq == 0:
                 # this loss is not normalized to batch size
                 comet_experiment.log_metrics(loss, prefix=f"{train_or_valid}", step=(epoch - 1) * len(data_loader) + itrain)
@@ -286,8 +289,6 @@ def train_mlpf(
                     start_epoch = checkpoint["extra_state"]["epoch"] + 1
 
     for epoch in range(start_epoch, num_epochs + 1):
-        if (rank == 0) or (rank == "cpu"):
-            _logger.info(f"Initiating epoch # {epoch}", color="bold")
         t0 = time.time()
 
         # training step
@@ -306,6 +307,11 @@ def train_mlpf(
         losses_v = train_and_valid(
             rank, world_size, model, optimizer, valid_loader, False, comet_experiment, comet_step_freq, epoch
         )
+
+        if comet_experiment:
+            comet_experiment.log_metrics(losses_t, prefix="epoch_train_loss", epoch=epoch)
+            comet_experiment.log_metrics(losses_v, prefix="epoch_valid_loss", epoch=epoch)
+            comet_experiment.log_epoch_end(epoch)
 
         if (rank == 0) or (rank == "cpu"):
             extra_state = {"epoch": epoch}
@@ -381,7 +387,8 @@ def train_mlpf(
                 + f"valid_loss={losses_v['Total']:.4f} "
                 + f"stale={stale_epochs} "
                 + f"time={round((t1-t0)/60, 2)}m "
-                + f"eta={round(eta, 1)}m"
+                + f"eta={round(eta, 1)}m",
+                color="bold",
             )
 
             for loss in losses_of_interest:
@@ -412,8 +419,6 @@ def train_mlpf(
             if tensorboard_writer:
                 tensorboard_writer.flush()
 
-        if comet_experiment:
-            comet_experiment.log_epoch_end(epoch)
     if world_size > 1:
         dist.barrier()
 
@@ -492,7 +497,7 @@ def run(rank, world_size, config, args, outdir, logfile):
                 config["comet_name"], comet_offline=config["comet_offline"], outdir=outdir
             )
             comet_experiment.set_name(f"rank_{rank}")
-            comet_experiment.log_parameter("run_id", outdir)
+            comet_experiment.log_parameter("run_id", Path(outdir).name)
             comet_experiment.log_parameter("world_size", world_size)
             comet_experiment.log_parameter("rank", rank)
             comet_experiment.log_parameters(config, prefix="config:")
@@ -634,17 +639,13 @@ def override_config(config, args):
 
 
 def device_agnostic_run(config, args, world_size, outdir):
-    if args.train:  # create a new outdir when training a model to never overwrite
+    if args.train:
         logfile = f"{outdir}/train.log"
         _configLogger("mlpf", filename=logfile)
-
-        os.system(f"cp {args.config} {outdir}/train-config.yaml")
     else:
         outdir = args.load
         logfile = f"{outdir}/test.log"
         _configLogger("mlpf", filename=logfile)
-
-        os.system(f"cp {args.config} {outdir}/test-config.yaml")
 
     if config["gpus"]:
         assert (
@@ -687,6 +688,9 @@ def train_ray_trial(config, args, outdir=None):
     world_rank = ray.train.get_context().get_world_rank()
     world_size = ray.train.get_context().get_world_size()
 
+    # keep writing the logs
+    _configLogger("mlpf", filename=f"{outdir}/train.log")
+
     model_kwargs = {
         "input_dim": len(X_FEATURES[config["dataset"]]),
         "num_classes": len(CLASS_LABELS[config["dataset"]]),
@@ -714,7 +718,7 @@ def train_ray_trial(config, args, outdir=None):
             config["comet_name"], comet_offline=config["comet_offline"], outdir=outdir
         )
         comet_experiment.set_name(f"world_rank_{world_rank}")
-        comet_experiment.log_parameter("run_id", outdir)
+        comet_experiment.log_parameter("run_id", Path(outdir).name)
         comet_experiment.log_parameter("world_size", world_size)
         comet_experiment.log_parameter("rank", rank)
         comet_experiment.log_parameter("world_rank", world_rank)
@@ -756,6 +760,8 @@ def run_ray_training(config, args, outdir):
 
     if not args.local:
         ray.init(address="auto")
+
+    _configLogger("mlpf", filename=f"{outdir}/train.log")
 
     num_workers = args.gpus
     scaling_config = ray.train.ScalingConfig(
@@ -822,14 +828,14 @@ def run_hpo(config, args):
 
     expdir = Path(config["raytune"]["local_dir"]) / name
     expdir.mkdir(parents=True, exist_ok=True)
+    dirname = Path(config["raytune"]["local_dir"]) / name
     shutil.copy(
         "mlpf/raytune/search_space.py",
-        str(Path(config["raytune"]["local_dir"]) / name / "search_space.py"),
+        str(dirname / "search_space.py"),
     )  # Copy the search space definition file to the train dir for later reference
-    shutil.copy(
-        args.config,
-        str(Path(config["raytune"]["local_dir"]) / name / "config.yaml"),
-    )  # Copy the config file to the train dir for later reference
+    # Save config for later reference. Note that saving happens after parameters are overwritten by cmd line args.
+    with open((dirname / "config.yaml"), "w") as file:
+        yaml.dump(config, file)
 
     if not args.local:
         ray.init(address="auto")

--- a/mlpf/pyg/training.py
+++ b/mlpf/pyg/training.py
@@ -440,24 +440,22 @@ def run(rank, world_size, config, args, outdir, logfile):
         _configLogger("mlpf", filename=logfile)
 
     if config["load"]:  # load a pre-trained model
-        outdir = config["load"]  # in case both --load and --train are provided
+        loaddir = config["load"]  # in case both --load and --train are provided
 
-        with open(f"{outdir}/model_kwargs.pkl", "rb") as f:
+        with open(f"{loaddir}/model_kwargs.pkl", "rb") as f:
             model_kwargs = pkl.load(f)
 
         model = MLPF(**model_kwargs)
         optimizer = torch.optim.AdamW(model.parameters(), lr=config["lr"])
 
         if args.load_checkpoint:
-            if not args.load_checkpoint.endswith(".pth"):
-                args.load_checkpoint += ".pth"
-            checkpoint = torch.load(f"{outdir}/checkpoints/{args.load_checkpoint}", map_location=torch.device(rank))
+            checkpoint = torch.load(f"{args.load_checkpoint}", map_location=torch.device(rank))
             if (rank == 0) or (rank == "cpu"):
-                _logger.info(f"Loaded model weights from {outdir}/checkpoints/{args.load_checkpoint}")
+                _logger.info(f"Loaded model weights from {loaddir}/checkpoints/{args.load_checkpoint}")
         else:
-            checkpoint = torch.load(f"{outdir}/best_weights.pth", map_location=torch.device(rank))
+            checkpoint = torch.load(f"{loaddir}/best_weights.pth", map_location=torch.device(rank))
             if (rank == 0) or (rank == "cpu"):
-                _logger.info(f"Loaded model weights from {outdir}/best_weights.pth")
+                _logger.info(f"Loaded model weights from {loaddir}/best_weights.pth")
 
         model, optimizer = load_checkpoint(checkpoint, model, optimizer)
 

--- a/mlpf/pyg/training.py
+++ b/mlpf/pyg/training.py
@@ -449,7 +449,12 @@ def run(rank, world_size, config, args, outdir, logfile):
     start_epoch = 1
 
     if config["load"]:  # load a pre-trained model
-        loaddir = str(Path(config["load"]).parent.parent)
+        if Path(config["load"]).name == "checkpoint.pth":
+            # the checkpoint is likely from a Ray Train run and we need to step one dir higher up
+            loaddir = str(Path(config["load"]).parent.parent.parent)
+        else:
+            # the checkpoint is likely from a DDP run and we need to step up one dir less
+            loaddir = str(Path(config["load"]).parent.parent)
 
         with open(f"{loaddir}/model_kwargs.pkl", "rb") as f:
             model_kwargs = pkl.load(f)

--- a/mlpf/pyg_pipeline.py
+++ b/mlpf/pyg_pipeline.py
@@ -81,6 +81,11 @@ def main():
             prefix=(args.prefix or "") + Path(args.config).stem + "_",
             experiments_dir=args.experiments_dir if args.experiments_dir else "experiments",
         )
+        # Save config for later reference. Note that saving happens after parameters are overwritten by cmd line args.
+        config_filename = "train-config.yaml" if args.train else "test-config.yaml"
+        with open((Path(outdir) / config_filename), "w") as file:
+            yaml.dump(config, file)
+
         if args.ray_train:
             run_ray_training(config, args, outdir)
         else:

--- a/mlpf/pyg_pipeline.py
+++ b/mlpf/pyg_pipeline.py
@@ -44,7 +44,11 @@ parser.add_argument("--num-epochs", type=int, default=None, help="number of trai
 parser.add_argument("--patience", type=int, default=None, help="patience before early stopping")
 parser.add_argument("--lr", type=float, default=None, help="learning rate")
 parser.add_argument(
-    "--conv-type", type=str, default=None, help="which graph layer to use", choices=["gravnet", "attention", "gnn_lsh"]
+    "--conv-type",
+    type=str,
+    default=None,
+    help="which graph layer to use",
+    choices=["gravnet", "attention", "gnn_lsh", "mamba"],
 )
 parser.add_argument("--make-plots", action="store_true", default=None, help="make plots of the test predictions")
 parser.add_argument("--export-onnx", action="store_true", default=None, help="exports the model to onnx")

--- a/mlpf/raytune/pt_search_space.py
+++ b/mlpf/raytune/pt_search_space.py
@@ -9,6 +9,7 @@ search_space = {
     "lr": samp([1e-4, 1e-3, 1e-2]),
     "gpu_batch_multiplier": samp([4]),
     # model arch parameters
+    "activation": samp(["elu"]),
     "conv_type": samp(["gravnet"]),  # can be "gnn_lsh", "gravnet", "attention"
     "embedding_dim": samp([128, 252, 512]),
     "width": samp([256, 512]),
@@ -16,44 +17,52 @@ search_space = {
     "dropout": samp([0.0]),
     "patience": samp([20]),
     # only for gravnet
-    "gravnet_k": samp([8, 16]),
+    "k": samp([8, 16]),
     "propagate_dimensions": samp([16, 32]),
     "space_dimensions": samp([4]),
+    # only for gnn-lsh
+    "bin_size": samp([640]),
+    "max_num_bins": samp([200]),
+    "distance_dim": samp([128]),
+    "layernorm": samp([True]),
+    "num_node_messages": samp([2]),
+    "ffn_dist_hidden_dim": samp([128]),
 }
 
 
 def set_hps_from_search_space(search_space, config):
-    if "lr" in search_space.keys():
-        config["lr"] = search_space["lr"]
-
-    if "gpu_batch_multiplier" in search_space.keys():
-        config["gpu_batch_multiplier"] = search_space["gpu_batch_multiplier"]
+    varaible_names = ["lr", "gpu_batch_multiplier"]
+    for var in varaible_names:
+        if var in search_space.keys():
+            config[var] = search_space[var]
 
     if "conv_type" in search_space.keys():
         conv_type = search_space["conv_type"]
         config["conv_type"] = conv_type
 
+        common_varaible_names = ["embedding_dim", "width", "num_convs", "activation"]
         if conv_type == "gnn_lsh" or conv_type == "gravnet" or conv_type == "attention":
-            if "embedding_dim" in search_space.keys():
-                config["model"][conv_type]["embedding_dim"] = search_space["embedding_dim"]
+            for var in common_varaible_names:
+                if var in search_space.keys():
+                    config["model"][conv_type][var] = search_space[var]
 
-            if "width" in search_space.keys():
-                config["model"][conv_type]["width"] = search_space["width"]
-
-            if "num_convs" in search_space.keys():
-                config["model"][conv_type]["num_convs"] = search_space["num_convs"]
-
-            if "num_convs" in search_space.keys():
-                config["model"][conv_type]["num_convs"] = search_space["num_convs"]
-
+        gravnet_variable_names = ["k", "propagate_dimensions", "space_dimensions"]
         if conv_type == "gravnet":
-            if "gravnet_k" in search_space.keys():
-                config["model"][conv_type]["k"] = search_space["gravnet_k"]
+            for var in gravnet_variable_names:
+                if var in search_space.keys():
+                    config["model"][conv_type][var] = search_space[var]
 
-            if "propagate_dimensions" in search_space.keys():
-                config["model"][conv_type]["propagate_dimensions"] = search_space["propagate_dimensions"]
-
-            if "space_dimensions" in search_space.keys():
-                config["model"][conv_type]["space_dimensions"] = search_space["space_dimensions"]
+        gnn_lsh_varaible_names = [
+            "bin_size",
+            "max_num_bins",
+            "distance_dim",
+            "layernorm",
+            "num_node_messages",
+            "ffn_dist_hidden_dim",
+        ]
+        if conv_type == "gnn_lsh":
+            for var in gnn_lsh_varaible_names:
+                if var in search_space.keys():
+                    config["model"][conv_type][var] = search_space[var]
 
     return config

--- a/mlpf/raytune/pt_search_space.py
+++ b/mlpf/raytune/pt_search_space.py
@@ -6,27 +6,31 @@ samp = choice
 # gnn scan
 search_space = {
     # optimizer parameters
-    "lr": samp([1e-4, 1e-3, 1e-2]),
-    "gpu_batch_multiplier": samp([4]),
+    "lr": samp([1e-4, 3e-4, 1e-3, 3e-3, 1e-2]),
+    "gpu_batch_multiplier": samp([1, 4, 8, 16]),
     # model arch parameters
-    "activation": samp(["elu"]),
+    "activation": samp(["elu", "relu", "relu6", "leakyrelu"]),
     "conv_type": samp(["gravnet"]),  # can be "gnn_lsh", "gravnet", "attention"
-    "embedding_dim": samp([128, 252, 512]),
-    "width": samp([256, 512]),
-    "num_convs": samp([3]),
-    "dropout": samp([0.0]),
-    "patience": samp([20]),
+    "embedding_dim": samp([32, 64, 128, 252, 512, 1024]),
+    "width": samp([32, 64, 128, 256, 512, 1024]),
+    "num_convs": samp([1, 2, 3, 4, 5, 6]),
+    "dropout": samp([0.0, 0.01, 0.1, 0.4]),
+    # "patience": samp([9999]),
     # only for gravnet
-    "k": samp([8, 16]),
-    "propagate_dimensions": samp([16, 32]),
+    "k": samp([8, 16, 32]),
+    "propagate_dimensions": samp([8, 16, 32, 64, 128]),
     "space_dimensions": samp([4]),
     # only for gnn-lsh
-    "bin_size": samp([640]),
-    "max_num_bins": samp([200]),
-    "distance_dim": samp([128]),
-    "layernorm": samp([True]),
-    "num_node_messages": samp([2]),
-    "ffn_dist_hidden_dim": samp([128]),
+    # "bin_size": samp([160, 320, 640]),
+    # "max_num_bins": samp([200]),
+    # "distance_dim": samp([16, 32, 64, 128, 256]),
+    # "layernorm": samp([True, False]),
+    # "num_node_messages": samp([1, 2, 3, 4, 5]),
+    # "ffn_dist_hidden_dim": samp([16, 32, 64, 128, 256]),
+    # mamba specific variables
+    "d_state": samp([16]),
+    "d_conv": samp([4]),
+    "expand": samp([2]),
 }
 
 
@@ -49,6 +53,18 @@ def set_hps_from_search_space(search_space, config):
         gravnet_variable_names = ["k", "propagate_dimensions", "space_dimensions"]
         if conv_type == "gravnet":
             for var in gravnet_variable_names:
+                if var in search_space.keys():
+                    config["model"][conv_type][var] = search_space[var]
+
+        attention_variables = ["num_heads"]
+        if conv_type == "attention":
+            for var in attention_variables:
+                if var in search_space.keys():
+                    config["model"][conv_type][var] = search_space[var]
+
+        mamba_variables = ["num_heads", "d_state", "d_conv", "expand"]
+        if conv_type == "mamba":
+            for var in mamba_variables:
                 if var in search_space.keys():
                     config["model"][conv_type][var] = search_space[var]
 

--- a/parameters/pyg-clic.yaml
+++ b/parameters/pyg-clic.yaml
@@ -58,6 +58,20 @@ model:
     # attention specific paramters
     num_heads: 2
 
+  mamba:
+    conv_type: mamba
+    embedding_dim: 128
+    width: 128
+    num_convs: 2
+    dropout: 0.0
+    activation: "elu"
+    # transformer specific paramters
+    num_heads: 2
+    # mamba specific paramters
+    d_state: 16
+    d_conv: 4
+    expand: 2
+
 raytune:
   local_dir: # Note: please specify an absolute path
   sched: asha # asha, hyperband

--- a/parameters/pyg-clic.yaml
+++ b/parameters/pyg-clic.yaml
@@ -8,6 +8,7 @@ load:
 num_epochs: 2
 patience: 20
 lr: 0.0001
+lr_schedule: constant  # constant, cosinedecay, onecycle
 conv_type: gnn_lsh
 ntrain:
 ntest:

--- a/parameters/pyg-clic.yaml
+++ b/parameters/pyg-clic.yaml
@@ -27,6 +27,12 @@ model:
     width: 512
     num_convs: 3
     dropout: 0.0
+    # gnn-lsh specific parameters
+    max_num_bins: 200
+    distance_dim: 128
+    layernorm: True
+    num_node_messages: 2
+    ffn_dist_hidden_dim: 128
 
   gravnet:
     conv_type: gravnet

--- a/parameters/pyg-clic.yaml
+++ b/parameters/pyg-clic.yaml
@@ -2,7 +2,7 @@ backend: pytorch
 
 dataset: clic
 data_dir:
-gpus: "0"
+gpus: 1
 gpu_batch_multiplier: 1
 load:
 num_epochs: 2

--- a/parameters/pyg-clic.yaml
+++ b/parameters/pyg-clic.yaml
@@ -27,7 +27,9 @@ model:
     width: 512
     num_convs: 3
     dropout: 0.0
+    activation: "elu"
     # gnn-lsh specific parameters
+    bin_size: 640
     max_num_bins: 200
     distance_dim: 128
     layernorm: True
@@ -39,17 +41,22 @@ model:
     embedding_dim: 512
     width: 512
     num_convs: 3
-    k: 16
-    propagate_dimensions: 22
-    space_dimensions: 4
     dropout: 0.0
+    activation: "elu"
+    # gravnet specific parameters
+    k: 16
+    propagate_dimensions: 32
+    space_dimensions: 4
 
   attention:
     conv_type: attention
-    embedding_dim: 128
-    width: 128
-    num_convs: 2
+    embedding_dim: 256
+    width: 256
+    num_convs: 3
     dropout: 0.0
+    activation: "elu"
+    # attention specific paramters
+    num_heads: 2
 
 raytune:
   local_dir: # Note: please specify an absolute path

--- a/parameters/pyg-cms-physical.yaml
+++ b/parameters/pyg-cms-physical.yaml
@@ -58,6 +58,20 @@ model:
     # attention specific paramters
     num_heads: 2
 
+  mamba:
+    conv_type: mamba
+    embedding_dim: 128
+    width: 128
+    num_convs: 2
+    dropout: 0.0
+    activation: "elu"
+    # transformer specific paramters
+    num_heads: 2
+    # mamba specific paramters
+    d_state: 16
+    d_conv: 4
+    expand: 2
+
 raytune:
   local_dir: # Note: please specify an absolute path
   sched: asha # asha, hyperband

--- a/parameters/pyg-cms-physical.yaml
+++ b/parameters/pyg-cms-physical.yaml
@@ -27,7 +27,9 @@ model:
     width: 512
     num_convs: 3
     dropout: 0.0
+    activation: "elu"
     # gnn-lsh specific parameters
+    bin_size: 640
     max_num_bins: 200
     distance_dim: 128
     layernorm: True
@@ -39,10 +41,12 @@ model:
     embedding_dim: 512
     width: 512
     num_convs: 3
+    dropout: 0.0
+    activation: "elu"
+    # gravnet specific parameters
     k: 16
     propagate_dimensions: 32
     space_dimensions: 4
-    dropout: 0.0
 
   attention:
     conv_type: attention
@@ -50,6 +54,9 @@ model:
     width: 256
     num_convs: 3
     dropout: 0.0
+    activation: "elu"
+    # attention specific paramters
+    num_heads: 2
 
 raytune:
   local_dir: # Note: please specify an absolute path

--- a/parameters/pyg-cms-physical.yaml
+++ b/parameters/pyg-cms-physical.yaml
@@ -8,6 +8,7 @@ load:
 num_epochs: 2
 patience: 20
 lr: 0.0001
+lr_schedule: constant  # constant, cosinedecay, onecycle
 conv_type: gnn_lsh
 ntrain:
 ntest:

--- a/parameters/pyg-cms-physical.yaml
+++ b/parameters/pyg-cms-physical.yaml
@@ -27,6 +27,12 @@ model:
     width: 512
     num_convs: 3
     dropout: 0.0
+    # gnn-lsh specific parameters
+    max_num_bins: 200
+    distance_dim: 128
+    layernorm: True
+    num_node_messages: 2
+    ffn_dist_hidden_dim: 128
 
   gravnet:
     conv_type: gravnet

--- a/parameters/pyg-cms-physical.yaml
+++ b/parameters/pyg-cms-physical.yaml
@@ -2,7 +2,7 @@ backend: pytorch
 
 dataset: cms
 data_dir:
-gpus: "0"
+gpus: 1
 gpu_batch_multiplier: 1
 load:
 num_epochs: 2
@@ -15,6 +15,9 @@ nvalid: 500
 num_workers: 0
 prefetch_factor:
 checkpoint_freq:
+comet_name: particleflow-pt
+comet_offline: False
+comet_step_freq: 100
 
 model:
   gnn_lsh:

--- a/parameters/pyg-cms-small-highqcd.yaml
+++ b/parameters/pyg-cms-small-highqcd.yaml
@@ -58,6 +58,20 @@ model:
     # attention specific paramters
     num_heads: 2
 
+  mamba:
+    conv_type: mamba
+    embedding_dim: 128
+    width: 128
+    num_convs: 2
+    dropout: 0.0
+    activation: "elu"
+    # transformer specific paramters
+    num_heads: 2
+    # mamba specific paramters
+    d_state: 16
+    d_conv: 4
+    expand: 2
+
 raytune:
   local_dir: # Note: please specify an absolute path
   sched: asha # asha, hyperband

--- a/parameters/pyg-cms-small-highqcd.yaml
+++ b/parameters/pyg-cms-small-highqcd.yaml
@@ -27,7 +27,9 @@ model:
     width: 512
     num_convs: 3
     dropout: 0.0
+    activation: "elu"
     # gnn-lsh specific parameters
+    bin_size: 640
     max_num_bins: 200
     distance_dim: 128
     layernorm: True
@@ -39,10 +41,12 @@ model:
     embedding_dim: 512
     width: 512
     num_convs: 3
+    dropout: 0.0
+    activation: "elu"
+    # gravnet specific parameters
     k: 16
     propagate_dimensions: 32
     space_dimensions: 4
-    dropout: 0.0
 
   attention:
     conv_type: attention
@@ -50,6 +54,9 @@ model:
     width: 256
     num_convs: 3
     dropout: 0.0
+    activation: "elu"
+    # attention specific paramters
+    num_heads: 2
 
 raytune:
   local_dir: # Note: please specify an absolute path

--- a/parameters/pyg-cms-small-highqcd.yaml
+++ b/parameters/pyg-cms-small-highqcd.yaml
@@ -8,6 +8,7 @@ load:
 num_epochs: 2
 patience: 20
 lr: 0.0001
+lr_schedule: constant  # constant, cosinedecay, onecycle
 conv_type: gnn_lsh
 ntrain:
 ntest:

--- a/parameters/pyg-cms-small-highqcd.yaml
+++ b/parameters/pyg-cms-small-highqcd.yaml
@@ -27,6 +27,12 @@ model:
     width: 512
     num_convs: 3
     dropout: 0.0
+    # gnn-lsh specific parameters
+    max_num_bins: 200
+    distance_dim: 128
+    layernorm: True
+    num_node_messages: 2
+    ffn_dist_hidden_dim: 128
 
   gravnet:
     conv_type: gravnet

--- a/parameters/pyg-cms-small-highqcd.yaml
+++ b/parameters/pyg-cms-small-highqcd.yaml
@@ -2,7 +2,7 @@ backend: pytorch
 
 dataset: cms
 data_dir:
-gpus: "0"
+gpus: 1
 gpu_batch_multiplier: 1
 load:
 num_epochs: 2
@@ -15,6 +15,9 @@ nvalid: 500
 num_workers: 0
 prefetch_factor:
 checkpoint_freq:
+comet_name: particleflow-pt
+comet_offline: False
+comet_step_freq: 10
 
 model:
   gnn_lsh:

--- a/parameters/pyg-cms-small.yaml
+++ b/parameters/pyg-cms-small.yaml
@@ -58,6 +58,20 @@ model:
     # attention specific paramters
     num_heads: 2
 
+  mamba:
+    conv_type: mamba
+    embedding_dim: 128
+    width: 128
+    num_convs: 2
+    dropout: 0.0
+    activation: "elu"
+    # transformer specific paramters
+    num_heads: 2
+    # mamba specific paramters
+    d_state: 16
+    d_conv: 4
+    expand: 2
+
 raytune:
   local_dir: # Note: please specify an absolute path
   sched: asha # asha, hyperband

--- a/parameters/pyg-cms-small.yaml
+++ b/parameters/pyg-cms-small.yaml
@@ -2,7 +2,7 @@ backend: pytorch
 
 dataset: cms
 data_dir:
-gpus: "0"
+gpus: 1
 gpu_batch_multiplier: 1
 load:
 num_epochs: 10

--- a/parameters/pyg-cms-small.yaml
+++ b/parameters/pyg-cms-small.yaml
@@ -27,7 +27,9 @@ model:
     width: 512
     num_convs: 3
     dropout: 0.0
+    activation: "elu"
     # gnn-lsh specific parameters
+    bin_size: 640
     max_num_bins: 200
     distance_dim: 128
     layernorm: True
@@ -39,10 +41,12 @@ model:
     embedding_dim: 512
     width: 512
     num_convs: 3
+    dropout: 0.0
+    activation: "elu"
+    # gravnet specific parameters
     k: 16
     propagate_dimensions: 32
     space_dimensions: 4
-    dropout: 0.0
 
   attention:
     conv_type: attention
@@ -50,6 +54,9 @@ model:
     width: 256
     num_convs: 3
     dropout: 0.0
+    activation: "elu"
+    # attention specific paramters
+    num_heads: 2
 
 raytune:
   local_dir: # Note: please specify an absolute path

--- a/parameters/pyg-cms-small.yaml
+++ b/parameters/pyg-cms-small.yaml
@@ -27,6 +27,12 @@ model:
     width: 512
     num_convs: 3
     dropout: 0.0
+    # gnn-lsh specific parameters
+    max_num_bins: 200
+    distance_dim: 128
+    layernorm: True
+    num_node_messages: 2
+    ffn_dist_hidden_dim: 128
 
   gravnet:
     conv_type: gravnet

--- a/parameters/pyg-cms-small.yaml
+++ b/parameters/pyg-cms-small.yaml
@@ -8,6 +8,7 @@ load:
 num_epochs: 10
 patience: 20
 lr: 0.0001
+lr_schedule: constant  # constant, cosinedecay, onecycle
 conv_type: gravnet
 ntrain: 500
 ntest: 500

--- a/parameters/pyg-cms-test-qcdhighpt.yaml
+++ b/parameters/pyg-cms-test-qcdhighpt.yaml
@@ -58,6 +58,20 @@ model:
     # attention specific paramters
     num_heads: 2
 
+  mamba:
+    conv_type: mamba
+    embedding_dim: 128
+    width: 128
+    num_convs: 2
+    dropout: 0.0
+    activation: "elu"
+    # transformer specific paramters
+    num_heads: 2
+    # mamba specific paramters
+    d_state: 16
+    d_conv: 4
+    expand: 2
+
 raytune:
   local_dir: # Note: please specify an absolute path
   sched: asha # asha, hyperband

--- a/parameters/pyg-cms-test-qcdhighpt.yaml
+++ b/parameters/pyg-cms-test-qcdhighpt.yaml
@@ -8,6 +8,7 @@ load:
 num_epochs: 2
 patience: 20
 lr: 0.0001
+lr_schedule: constant  # constant, cosinedecay, onecycle
 conv_type: gnn_lsh
 ntrain:
 ntest:

--- a/parameters/pyg-cms-test-qcdhighpt.yaml
+++ b/parameters/pyg-cms-test-qcdhighpt.yaml
@@ -27,6 +27,12 @@ model:
     width: 512
     num_convs: 3
     dropout: 0.0
+    # gnn-lsh specific parameters
+    max_num_bins: 200
+    distance_dim: 128
+    layernorm: True
+    num_node_messages: 2
+    ffn_dist_hidden_dim: 128
 
   gravnet:
     conv_type: gravnet

--- a/parameters/pyg-cms-test-qcdhighpt.yaml
+++ b/parameters/pyg-cms-test-qcdhighpt.yaml
@@ -2,7 +2,7 @@ backend: pytorch
 
 dataset: cms
 data_dir:
-gpus: "0"
+gpus: 1
 gpu_batch_multiplier: 1
 load:
 num_epochs: 2

--- a/parameters/pyg-cms-test-qcdhighpt.yaml
+++ b/parameters/pyg-cms-test-qcdhighpt.yaml
@@ -27,7 +27,9 @@ model:
     width: 512
     num_convs: 3
     dropout: 0.0
+    activation: "elu"
     # gnn-lsh specific parameters
+    bin_size: 640
     max_num_bins: 200
     distance_dim: 128
     layernorm: True
@@ -39,17 +41,22 @@ model:
     embedding_dim: 512
     width: 512
     num_convs: 3
-    k: 16
-    propagate_dimensions: 22
-    space_dimensions: 4
     dropout: 0.0
+    activation: "elu"
+    # gravnet specific parameters
+    k: 16
+    propagate_dimensions: 32
+    space_dimensions: 4
 
   attention:
     conv_type: attention
-    embedding_dim: 128
-    width: 128
-    num_convs: 2
+    embedding_dim: 256
+    width: 256
+    num_convs: 3
     dropout: 0.0
+    activation: "elu"
+    # attention specific paramters
+    num_heads: 2
 
 raytune:
   local_dir: # Note: please specify an absolute path

--- a/parameters/pyg-cms.yaml
+++ b/parameters/pyg-cms.yaml
@@ -58,6 +58,20 @@ model:
     # attention specific paramters
     num_heads: 2
 
+  mamba:
+    conv_type: mamba
+    embedding_dim: 128
+    width: 128
+    num_convs: 2
+    dropout: 0.0
+    activation: "elu"
+    # transformer specific paramters
+    num_heads: 2
+    # mamba specific paramters
+    d_state: 16
+    d_conv: 4
+    expand: 2
+
 raytune:
   local_dir: # Note: please specify an absolute path
   sched: asha # asha, hyperband
@@ -113,7 +127,7 @@ train_dataset:
         cms_pf_single_proton:
           version: 1.6.0
     multiparticlegun:
-      batch_size: 2
+      batch_size: 4
       samples:
         cms_pf_multi_particle_gun:
           version: 1.6.0
@@ -162,7 +176,7 @@ test_dataset:
         cms_pf_single_proton:
           version: 1.6.0
     multiparticlegun:
-      batch_size: 2
+      batch_size: 4
       samples:
         cms_pf_multi_particle_gun:
           version: 1.6.0

--- a/parameters/pyg-cms.yaml
+++ b/parameters/pyg-cms.yaml
@@ -5,14 +5,14 @@ data_dir:
 gpus: 1
 gpu_batch_multiplier: 1
 load:
-num_epochs: 2
+num_epochs: 50
 patience: 20
 lr: 0.0001
-lr_schedule: constant  # constant, cosinedecay, onecycle
+lr_schedule: cosinedecay  # constant, cosinedecay, onecycle
 conv_type: gnn_lsh
 ntrain:
 ntest:
-nvalid: 500
+nvalid:
 num_workers: 0
 prefetch_factor:
 checkpoint_freq:
@@ -137,8 +137,41 @@ valid_dataset:
     physical:
       batch_size: 1
       samples:
+        cms_pf_ttbar:
+          version: 1.6.0
+        cms_pf_qcd:
+          version: 1.6.0
+        cms_pf_ztt:
+          version: 1.6.0
         cms_pf_qcd_high_pt:
           version: 1.6.0
+        cms_pf_sms_t1tttt:
+          version: 1.6.0
+    gun:
+      batch_size: 20
+      samples:
+        cms_pf_single_electron:
+          version: 1.6.0
+        cms_pf_single_gamma:
+          version: 1.6.0
+        cms_pf_single_pi0:
+          version: 1.6.0
+        cms_pf_single_neutron:
+          version: 1.6.0
+        cms_pf_single_pi:
+          version: 1.6.0
+        cms_pf_single_tau:
+          version: 1.6.0
+        cms_pf_single_mu:
+          version: 1.6.0
+        cms_pf_single_proton:
+          version: 1.6.0
+    multiparticlegun:
+      batch_size: 4
+      samples:
+        cms_pf_multi_particle_gun:
+          version: 1.6.0
+
 
 test_dataset:
   cms:

--- a/parameters/pyg-cms.yaml
+++ b/parameters/pyg-cms.yaml
@@ -8,6 +8,7 @@ load:
 num_epochs: 2
 patience: 20
 lr: 0.0001
+lr_schedule: constant  # constant, cosinedecay, onecycle
 conv_type: gnn_lsh
 ntrain:
 ntest:

--- a/parameters/pyg-cms.yaml
+++ b/parameters/pyg-cms.yaml
@@ -27,6 +27,12 @@ model:
     width: 512
     num_convs: 3
     dropout: 0.0
+    # gnn-lsh specific parameters
+    max_num_bins: 200
+    distance_dim: 128
+    layernorm: True
+    num_node_messages: 2
+    ffn_dist_hidden_dim: 128
 
   gravnet:
     conv_type: gravnet

--- a/parameters/pyg-cms.yaml
+++ b/parameters/pyg-cms.yaml
@@ -2,7 +2,7 @@ backend: pytorch
 
 dataset: cms
 data_dir:
-gpus: "0"
+gpus: 1
 gpu_batch_multiplier: 1
 load:
 num_epochs: 2

--- a/parameters/pyg-cms.yaml
+++ b/parameters/pyg-cms.yaml
@@ -27,7 +27,9 @@ model:
     width: 512
     num_convs: 3
     dropout: 0.0
+    activation: "elu"
     # gnn-lsh specific parameters
+    bin_size: 640
     max_num_bins: 200
     distance_dim: 128
     layernorm: True
@@ -39,17 +41,22 @@ model:
     embedding_dim: 512
     width: 512
     num_convs: 3
-    k: 16
-    propagate_dimensions: 22
-    space_dimensions: 4
     dropout: 0.0
+    activation: "elu"
+    # gravnet specific parameters
+    k: 16
+    propagate_dimensions: 32
+    space_dimensions: 4
 
   attention:
     conv_type: attention
-    embedding_dim: 128
-    width: 128
-    num_convs: 2
+    embedding_dim: 256
+    width: 256
+    num_convs: 3
     dropout: 0.0
+    activation: "elu"
+    # attention specific paramters
+    num_heads: 2
 
 raytune:
   local_dir: # Note: please specify an absolute path

--- a/parameters/pyg-delphes.yaml
+++ b/parameters/pyg-delphes.yaml
@@ -58,6 +58,20 @@ model:
     # attention specific paramters
     num_heads: 2
 
+  mamba:
+    conv_type: mamba
+    embedding_dim: 128
+    width: 128
+    num_convs: 2
+    dropout: 0.0
+    activation: "elu"
+    # transformer specific paramters
+    num_heads: 2
+    # mamba specific paramters
+    d_state: 16
+    d_conv: 4
+    expand: 2
+
 raytune:
   local_dir: # Note: please specify an absolute path
   sched: asha # asha, hyperband

--- a/parameters/pyg-delphes.yaml
+++ b/parameters/pyg-delphes.yaml
@@ -8,6 +8,7 @@ load:
 num_epochs: 2
 patience: 20
 lr: 0.0001
+lr_schedule: constant  # constant, cosinedecay, onecycle
 conv_type: gnn_lsh
 ntrain:
 ntest:

--- a/parameters/pyg-delphes.yaml
+++ b/parameters/pyg-delphes.yaml
@@ -27,6 +27,12 @@ model:
     width: 512
     num_convs: 3
     dropout: 0.0
+    # gnn-lsh specific parameters
+    max_num_bins: 200
+    distance_dim: 128
+    layernorm: True
+    num_node_messages: 2
+    ffn_dist_hidden_dim: 128
 
   gravnet:
     conv_type: gravnet

--- a/parameters/pyg-delphes.yaml
+++ b/parameters/pyg-delphes.yaml
@@ -2,7 +2,7 @@ backend: pytorch
 
 dataset: delphes
 data_dir:
-gpus: "0"
+gpus: 1
 gpu_batch_multiplier: 1
 load:
 num_epochs: 2

--- a/parameters/pyg-delphes.yaml
+++ b/parameters/pyg-delphes.yaml
@@ -27,7 +27,9 @@ model:
     width: 512
     num_convs: 3
     dropout: 0.0
+    activation: "elu"
     # gnn-lsh specific parameters
+    bin_size: 640
     max_num_bins: 200
     distance_dim: 128
     layernorm: True
@@ -39,17 +41,22 @@ model:
     embedding_dim: 512
     width: 512
     num_convs: 3
-    k: 16
-    propagate_dimensions: 22
-    space_dimensions: 4
     dropout: 0.0
+    activation: "elu"
+    # gravnet specific parameters
+    k: 16
+    propagate_dimensions: 32
+    space_dimensions: 4
 
   attention:
     conv_type: attention
-    embedding_dim: 128
-    width: 128
-    num_convs: 2
+    embedding_dim: 256
+    width: 256
+    num_convs: 3
     dropout: 0.0
+    activation: "elu"
+    # attention specific paramters
+    num_heads: 2
 
 raytune:
   local_dir: # Note: please specify an absolute path

--- a/parameters/pyg-workflow-test.yaml
+++ b/parameters/pyg-workflow-test.yaml
@@ -27,7 +27,9 @@ model:
     width: 512
     num_convs: 3
     dropout: 0.0
+    activation: "elu"
     # gnn-lsh specific parameters
+    bin_size: 640
     max_num_bins: 200
     distance_dim: 128
     layernorm: True
@@ -39,17 +41,22 @@ model:
     embedding_dim: 512
     width: 512
     num_convs: 3
-    k: 16
-    propagate_dimensions: 22
-    space_dimensions: 4
     dropout: 0.0
+    activation: "elu"
+    # gravnet specific parameters
+    k: 16
+    propagate_dimensions: 32
+    space_dimensions: 4
 
   attention:
     conv_type: attention
-    embedding_dim: 128
-    width: 128
-    num_convs: 2
+    embedding_dim: 256
+    width: 256
+    num_convs: 3
     dropout: 0.0
+    activation: "elu"
+    # attention specific paramters
+    num_heads: 2
 
 train_dataset:
   cms:

--- a/parameters/pyg-workflow-test.yaml
+++ b/parameters/pyg-workflow-test.yaml
@@ -8,6 +8,7 @@ load:
 num_epochs: 2
 patience: 20
 lr: 0.0001
+lr_schedule: constant  # constant, cosinedecay, onecycle
 conv_type: gravnet
 ntrain:
 ntest:

--- a/parameters/pyg-workflow-test.yaml
+++ b/parameters/pyg-workflow-test.yaml
@@ -58,6 +58,20 @@ model:
     # attention specific paramters
     num_heads: 2
 
+  mamba:
+    conv_type: mamba
+    embedding_dim: 128
+    width: 128
+    num_convs: 2
+    dropout: 0.0
+    activation: "elu"
+    # transformer specific paramters
+    num_heads: 2
+    # mamba specific paramters
+    d_state: 16
+    d_conv: 4
+    expand: 2
+
 train_dataset:
   cms:
     physical:

--- a/parameters/pyg-workflow-test.yaml
+++ b/parameters/pyg-workflow-test.yaml
@@ -27,6 +27,12 @@ model:
     width: 512
     num_convs: 3
     dropout: 0.0
+    # gnn-lsh specific parameters
+    max_num_bins: 200
+    distance_dim: 128
+    layernorm: True
+    num_node_messages: 2
+    ffn_dist_hidden_dim: 128
 
   gravnet:
     conv_type: gravnet

--- a/scripts/flatiron/pt_raytrain_a100.slurm
+++ b/scripts/flatiron/pt_raytrain_a100.slurm
@@ -2,7 +2,7 @@
 
 # Walltime limit
 #SBATCH -t 1:00:00
-#SBATCH -N 2
+#SBATCH -N 1
 #SBATCH --exclusive
 #SBATCH --tasks-per-node=1
 #SBATCH -p gpu
@@ -11,7 +11,7 @@
 #SBATCH --constraint=a100-80gb,ib
 
 # Job name
-#SBATCH -J pt_train
+#SBATCH -J pt_raytrain
 
 # Output and error logs
 #SBATCH -o logs_slurm/log_%x_%j.out

--- a/scripts/flatiron/pt_raytrain_a100.slurm
+++ b/scripts/flatiron/pt_raytrain_a100.slurm
@@ -2,7 +2,7 @@
 
 # Walltime limit
 #SBATCH -t 1:00:00
-#SBATCH -N 1
+#SBATCH -N 2
 #SBATCH --exclusive
 #SBATCH --tasks-per-node=1
 #SBATCH -p gpu
@@ -35,42 +35,44 @@ export CUDA_VISIBLE_DEVICES=0,1,2,3
 num_gpus=${SLURM_GPUS_PER_TASK}  # gpus per compute node
 
 
-################# DON NOT CHANGE THINGS HERE UNLESS YOU KNOW WHAT YOU ARE DOING ###############
-redis_password=$(uuidgen)
-export redis_password
-echo "Redis password: ${redis_password}"
+if [ "$SLURM_JOB_NUM_NODES" -gt 1 ]; then
+  ################# DON NOT CHANGE THINGS HERE UNLESS YOU KNOW WHAT YOU ARE DOING ###############
+  redis_password=$(uuidgen)
+  export redis_password
+  echo "Redis password: ${redis_password}"
 
-nodes=$(scontrol show hostnames $SLURM_JOB_NODELIST) # Getting the node names
-nodes_array=( $nodes )
+  nodes=$(scontrol show hostnames $SLURM_JOB_NODELIST) # Getting the node names
+  nodes_array=( $nodes )
 
-node_1=${nodes_array[0]}
-ip=$(srun --nodes=1 --ntasks=1 -w $node_1 hostname --ip-address) # making redis-address
-port=6379
-ip_head=$ip:$port
-export ip_head
-echo "IP Head: $ip_head"
+  node_1=${nodes_array[0]}
+  ip=$(srun --nodes=1 --ntasks=1 -w $node_1 hostname --ip-address) # making redis-address
+  port=6379
+  ip_head=$ip:$port
+  export ip_head
+  echo "IP Head: $ip_head"
 
-echo "STARTING HEAD at $node_1"
-srun --nodes=1 --ntasks=1 -w $node_1 \
-  ray start --head --node-ip-address="$node_1" --port=$port \
-  --num-cpus $((SLURM_CPUS_PER_TASK)) --num-gpus $num_gpus --block &
-
-sleep 10
-
-worker_num=$(($SLURM_JOB_NUM_NODES - 1)) #number of nodes other than the head node
-for ((  i=1; i<=$worker_num; i++ ))
-do
-  node_i=${nodes_array[$i]}
-  echo "STARTING WORKER $i at $node_i"
-  srun --nodes=1 --ntasks=1 -w $node_i \
-    ray start --address "$node_1":"$port" \
+  echo "STARTING HEAD at $node_1"
+  srun --nodes=1 --ntasks=1 -w $node_1 \
+    ray start --head --node-ip-address="$node_1" --port=$port \
     --num-cpus $((SLURM_CPUS_PER_TASK)) --num-gpus $num_gpus --block &
-  sleep 5
-done
 
-echo All Ray workers started.
-##############################################################################################
-# call your code below
+  sleep 10
+
+  worker_num=$(($SLURM_JOB_NUM_NODES - 1)) #number of nodes other than the head node
+  for ((  i=1; i<=$worker_num; i++ ))
+  do
+    node_i=${nodes_array[$i]}
+    echo "STARTING WORKER $i at $node_i"
+    srun --nodes=1 --ntasks=1 -w $node_i \
+      ray start --address "$node_1":"$port" \
+      --num-cpus $((SLURM_CPUS_PER_TASK)) --num-gpus $num_gpus --block &
+    sleep 5
+  done
+
+  echo All Ray workers started.
+  ##############################################################################################
+  # call your code below
+fi
 
 
 echo 'Starting training.'
@@ -83,6 +85,8 @@ python3 -u mlpf/pyg_pipeline.py --train --ray-train \
     --gpu-batch-multiplier 4 \
     --num-workers 1 \
     --prefetch-factor 2 \
-    --experiments-dir /mnt/ceph/users/ewulff/particleflow/experiments
+    --experiments-dir /mnt/ceph/users/ewulff/particleflow/experiments \
+    --local \
+    --comet
 
 echo 'Training done.'

--- a/scripts/flatiron/pt_raytrain_h100.slurm
+++ b/scripts/flatiron/pt_raytrain_h100.slurm
@@ -1,8 +1,8 @@
 #!/bin/sh
 
 # Walltime limit
-#SBATCH -t 1:00:00
-#SBATCH -N 2
+#SBATCH -t 168:00:00
+#SBATCH -N 1
 #SBATCH --exclusive
 #SBATCH --tasks-per-node=1
 #SBATCH -p gpu
@@ -34,43 +34,44 @@ python3 --version
 export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
 num_gpus=${SLURM_GPUS_PER_TASK}  # gpus per compute node
 
+if [ "$SLURM_JOB_NUM_NODES" -gt 1 ]; then
+  ################# DON NOT CHANGE THINGS HERE UNLESS YOU KNOW WHAT YOU ARE DOING ###############
+  redis_password=$(uuidgen)
+  export redis_password
+  echo "Redis password: ${redis_password}"
 
-################# DON NOT CHANGE THINGS HERE UNLESS YOU KNOW WHAT YOU ARE DOING ###############
-redis_password=$(uuidgen)
-export redis_password
-echo "Redis password: ${redis_password}"
+  nodes=$(scontrol show hostnames $SLURM_JOB_NODELIST) # Getting the node names
+  nodes_array=( $nodes )
 
-nodes=$(scontrol show hostnames $SLURM_JOB_NODELIST) # Getting the node names
-nodes_array=( $nodes )
+  node_1=${nodes_array[0]}
+  ip=$(srun --nodes=1 --ntasks=1 -w $node_1 hostname --ip-address) # making redis-address
+  port=6379
+  ip_head=$ip:$port
+  export ip_head
+  echo "IP Head: $ip_head"
 
-node_1=${nodes_array[0]}
-ip=$(srun --nodes=1 --ntasks=1 -w $node_1 hostname --ip-address) # making redis-address
-port=6379
-ip_head=$ip:$port
-export ip_head
-echo "IP Head: $ip_head"
-
-echo "STARTING HEAD at $node_1"
-srun --nodes=1 --ntasks=1 -w $node_1 \
-  ray start --head --node-ip-address="$node_1" --port=$port \
-  --num-cpus $((SLURM_CPUS_PER_TASK)) --num-gpus $num_gpus --block &
-
-sleep 10
-
-worker_num=$(($SLURM_JOB_NUM_NODES - 1)) #number of nodes other than the head node
-for ((  i=1; i<=$worker_num; i++ ))
-do
-  node_i=${nodes_array[$i]}
-  echo "STARTING WORKER $i at $node_i"
-  srun --nodes=1 --ntasks=1 -w $node_i \
-    ray start --address "$node_1":"$port" \
+  echo "STARTING HEAD at $node_1"
+  srun --nodes=1 --ntasks=1 -w $node_1 \
+    ray start --head --node-ip-address="$node_1" --port=$port \
     --num-cpus $((SLURM_CPUS_PER_TASK)) --num-gpus $num_gpus --block &
-  sleep 5
-done
 
-echo All Ray workers started.
-##############################################################################################
-# call your code below
+  sleep 10
+
+  worker_num=$(($SLURM_JOB_NUM_NODES - 1)) #number of nodes other than the head node
+  for ((  i=1; i<=$worker_num; i++ ))
+  do
+    node_i=${nodes_array[$i]}
+    echo "STARTING WORKER $i at $node_i"
+    srun --nodes=1 --ntasks=1 -w $node_i \
+      ray start --address "$node_1":"$port" \
+      --num-cpus $((SLURM_CPUS_PER_TASK)) --num-gpus $num_gpus --block &
+    sleep 5
+  done
+
+  echo All Ray workers started.
+  ##############################################################################################
+  # call your code below
+fi
 
 
 echo 'Starting training.'
@@ -83,6 +84,8 @@ python3 -u mlpf/pyg_pipeline.py --train --ray-train \
     --gpu-batch-multiplier 4 \
     --num-workers 1 \
     --prefetch-factor 2 \
-    --experiments-dir /mnt/ceph/users/ewulff/particleflow/experiments
+    --experiments-dir /mnt/ceph/users/ewulff/particleflow/experiments \
+    --local \
+    --comet
 
 echo 'Training done.'

--- a/scripts/flatiron/pt_raytrain_h100.slurm
+++ b/scripts/flatiron/pt_raytrain_h100.slurm
@@ -11,7 +11,7 @@
 #SBATCH --constraint=h100,ib
 
 # Job name
-#SBATCH -J pt_train
+#SBATCH -J pt_raytrain
 
 # Output and error logs
 #SBATCH -o logs_slurm/log_%x_%j.out

--- a/scripts/flatiron/pt_raytune_a100_1GPUperTrial.sh
+++ b/scripts/flatiron/pt_raytune_a100_1GPUperTrial.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #SBATCH -t 168:00:00
-#SBATCH -N 6
+#SBATCH -N 4
 #SBATCH --tasks-per-node=1
 #SBATCH -p gpu
 #SBATCH --constraint=a100-80gb,ib
@@ -75,8 +75,7 @@ python3 -u mlpf/pyg_pipeline.py --train \
     --config $1 \
     --hpo $2 \
     --ray-cpus $((SLURM_CPUS_PER_TASK/4)) \
-    --ray-gpus 1 \
-    --gpus "0" \
+    --gpus 1 \
     --gpu-batch-multiplier 4 \
     --num-workers 1 \
     --prefetch-factor 2

--- a/scripts/flatiron/pt_raytune_a100_4GPUsperTrial.sh
+++ b/scripts/flatiron/pt_raytune_a100_4GPUsperTrial.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #SBATCH -t 168:00:00
-#SBATCH -N 6
+#SBATCH -N 2
 #SBATCH --tasks-per-node=1
 #SBATCH -p gpu
 #SBATCH --constraint=a100-80gb,ib
@@ -75,8 +75,7 @@ python3 -u mlpf/pyg_pipeline.py --train \
     --config $1 \
     --hpo $2 \
     --ray-cpus $((SLURM_CPUS_PER_TASK)) \
-    --ray-gpus $num_gpus \
-    --gpus "0,1,2,3" \
+    --gpus $num_gpus \
     --gpu-batch-multiplier 4 \
     --num-workers 1 \
     --prefetch-factor 2

--- a/scripts/flatiron/pt_raytune_h100_1GPUperTrial.sh
+++ b/scripts/flatiron/pt_raytune_h100_1GPUperTrial.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #SBATCH -t 168:00:00
-#SBATCH -N 3
+#SBATCH -N 2
 #SBATCH --tasks-per-node=1
 #SBATCH -p gpu
 #SBATCH --constraint=h100,ib
@@ -31,7 +31,7 @@ which python3
 python3 --version
 
 export CUDA_VISIBLE_DEVICES=0,1,2,3
-num_gpus=8
+num_gpus=${SLURM_GPUS_PER_TASK}  # gpus per compute node
 
 
 ################# DON NOT CHANGE THINGS HERE UNLESS YOU KNOW WHAT YOU ARE DOING ###############
@@ -75,8 +75,7 @@ python3 -u mlpf/pyg_pipeline.py --train \
     --config $1 \
     --hpo $2 \
     --ray-cpus $((SLURM_CPUS_PER_TASK/8)) \
-    --ray-gpus 1 \
-    --gpus "0" \
+    --gpus 1 \
     --gpu-batch-multiplier 4 \
     --num-workers 1 \
     --prefetch-factor 2

--- a/scripts/flatiron/pt_raytune_h100_2GPUsperTrial.sh
+++ b/scripts/flatiron/pt_raytune_h100_2GPUsperTrial.sh
@@ -75,8 +75,7 @@ python3 -u mlpf/pyg_pipeline.py --train \
     --config $1 \
     --hpo $2 \
     --ray-cpus $((SLURM_CPUS_PER_TASK/4)) \
-    --ray-gpus 2 \
-    --gpus "0,1" \
+    --gpus 2 \
     --gpu-batch-multiplier 4 \
     --num-workers 1 \
     --prefetch-factor 2

--- a/scripts/flatiron/pt_raytune_h100_4GPUsperTrial.sh
+++ b/scripts/flatiron/pt_raytune_h100_4GPUsperTrial.sh
@@ -75,8 +75,7 @@ python3 -u mlpf/pyg_pipeline.py --train \
     --config $1 \
     --hpo $2 \
     --ray-cpus $((SLURM_CPUS_PER_TASK/2)) \
-    --ray-gpus 4 \
-    --gpus "0,1,2,3" \
+    --gpus 4 \
     --gpu-batch-multiplier 4 \
     --num-workers 1 \
     --prefetch-factor 2

--- a/scripts/flatiron/pt_raytune_h100_8GPUsperTrial.sh
+++ b/scripts/flatiron/pt_raytune_h100_8GPUsperTrial.sh
@@ -75,8 +75,7 @@ python3 -u mlpf/pyg_pipeline.py --train \
     --config $1 \
     --hpo $2 \
     --ray-cpus $((SLURM_CPUS_PER_TASK)) \
-    --ray-gpus $num_gpus \
-    --gpus "0,1,2,3,4,5,6,7" \
+    --gpus 8 \
     --gpu-batch-multiplier 4 \
     --num-workers 1 \
     --prefetch-factor 2

--- a/scripts/flatiron/pt_test.slurm
+++ b/scripts/flatiron/pt_test.slurm
@@ -1,12 +1,13 @@
 #!/bin/sh
 
 # Walltime limit
-#SBATCH -t 2:00:00
+#SBATCH -t 4:00:00
 #SBATCH -N 1
 #SBATCH --exclusive
 #SBATCH --tasks-per-node=1
 #SBATCH -p gpu
 #SBATCH --gpus-per-task=4
+#SBATCH --cpus-per-task=64
 #SBATCH --constraint=a100-80gb,ib
 
 # Job name
@@ -35,8 +36,7 @@ echo 'Starting training.'
 CUDA_VISIBLE_DEVICES=0,1,2,3 python3 -u mlpf/pyg_pipeline.py \
     --config $1 \
     --load $2 \
-    --gpus "0,1,2,3" \
-    --conv-type gnn_lsh \
+    --gpus 4 \
     --gpu-batch-multiplier 4 \
     --num-workers 1 \
     --prefetch-factor 2 \

--- a/scripts/flatiron/pt_train.slurm
+++ b/scripts/flatiron/pt_train.slurm
@@ -36,10 +36,11 @@ echo 'Starting training.'
 CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 python3 -u mlpf/pyg_pipeline.py --train \
     --config $1 \
     --prefix $2 \
-    --gpus "0,1,2,3,4,5,6,7" \
+    --gpus 8 \
     --gpu-batch-multiplier 4 \
     --num-workers 1 \
     --prefetch-factor 2 \
-    --checkpoint-freq 1
+    --checkpoint-freq 1 \
+    --comet
 
 echo 'Training done.'


### PR DESCRIPTION
Implement LR schedules in the PyTorch training code. Add MambaLayer and make it configurable through parameter config files and for HPO.

Also contains the following changes.

- `--load` now takes as input the path to a saved checkpoint from which to start a new training. I.e., a training starts from epoch 1, with LR schedules starting from the beginning. The only thing that is loaded is the pre-trained model weights from the checkpoint.
- `--resume-training` is a new command line arg that takes as input a path to a training directory containing an unfinished training and attempts to restore it and continue the training from the last saved checkpoint.

![Screenshot 2023-12-06 at 13 28 12](https://github.com/jpata/particleflow/assets/31319227/a4e34d60-ff92-4d83-87af-1c0102ff95d3)
*Learning rate versus training step of a training using the `cosinedecay` LR schedule and was interrupted halfway through and then continued.*

![Screenshot 2023-12-06 at 13 27 41](https://github.com/jpata/particleflow/assets/31319227/a11933b7-fa44-4c54-9bb8-6e0d13723778)
*Learning rate versus training step of a training using the `onecycle` LR schedule and was interrupted halfway through and then continued.*
