### PR TITLE
track individual particle loss components, speedup inference

### DIFF
--- a/mlpf/pyg/PFDataset.py
+++ b/mlpf/pyg/PFDataset.py
@@ -27,6 +27,7 @@ class TFDSDataSource:
         ret = [self.ds.dataset_info.features.deserialize_example_np(record, decoders=self.ds.decoders) for record in records]
         if len(item) == 1:
             ret = ret[0]
+
         return ret
 
     def __len__(self):

--- a/mlpf/pyg/inference.py
+++ b/mlpf/pyg/inference.py
@@ -131,7 +131,7 @@ def predict_one_batch(conv_type, model, i, batch, rank, jetdef, jet_ptcut, jet_m
 
 
 @torch.no_grad()
-def run_predictions(world_size, rank, model, loader, sample, outpath, jetdef, jet_ptcut=15.0, jet_match_dr=0.1, dir_name=""):
+def run_predictions(world_size, rank, model, loader, sample, outpath, jetdef, jet_ptcut=5.0, jet_match_dr=0.1, dir_name=""):
     """Runs inference on the given sample and stores the output as .parquet files."""
     if world_size > 1:
         conv_type = model.module.conv_type

--- a/mlpf/pyg/inference.py
+++ b/mlpf/pyg/inference.py
@@ -28,8 +28,110 @@ from .logger import _logger
 from .utils import CLASS_NAMES, unpack_predictions, unpack_target
 
 
+def predict_one_batch(conv_type, model, i, batch, rank, jetdef, jet_ptcut, jet_match_dr, outpath, dir_name, sample):
+    if conv_type != "gravnet":
+        X_pad, mask = torch_geometric.utils.to_dense_batch(batch.X, batch.batch)
+        batch_pad = Batch(X=X_pad, mask=mask).to(rank)
+        ypred = model(batch_pad.X, batch_pad.mask)
+        ypred = ypred[0][mask], ypred[1][mask], ypred[2][mask]
+    else:
+        _batch = batch.to(rank)
+        ypred = model(_batch.X, _batch.batch)
+
+    ygen = unpack_target(batch.ygen)
+    ycand = unpack_target(batch.ycand)
+    ypred = unpack_predictions(ypred)
+
+    for k, v in ygen.items():
+        ygen[k] = v.detach().cpu()
+    for k, v in ycand.items():
+        ycand[k] = v.detach().cpu()
+    for k, v in ypred.items():
+        ypred[k] = v.detach().cpu()
+
+    # loop over the batch to disentangle the events
+    batch_ids = batch.batch.cpu().numpy()
+
+    jets_coll = {}
+
+    cs = np.unique(batch_ids, return_counts=True)[1]
+    Xs = awkward.unflatten(awkward.from_numpy(batch.X.numpy()), cs)
+
+    for typ, ydata in zip(["gen", "cand"], [ygen, ycand]):
+        clsid = awkward.unflatten(ydata["cls_id"], cs)
+        msk = clsid != 0
+        p4 = awkward.unflatten(ydata["p4"], cs)
+        vec = vector.awk(
+            awkward.zip(
+                {
+                    "pt": p4[msk][:, :, 0],
+                    "eta": p4[msk][:, :, 1],
+                    "phi": p4[msk][:, :, 2],
+                    "e": p4[msk][:, :, 3],
+                }
+            )
+        )
+        cluster = fastjet.ClusterSequence(vec.to_xyzt(), jetdef)
+        jets_coll[typ] = cluster.inclusive_jets(min_pt=jet_ptcut)
+
+    # in case of no predicted particles in the batch
+    if torch.sum(ypred["cls_id"] != 0) == 0:
+        vec = vector.awk(
+            awkward.zip(
+                {
+                    "pt": build_dummy_array(len(vec), np.float64),
+                    "eta": build_dummy_array(len(vec), np.float64),
+                    "phi": build_dummy_array(len(vec), np.float64),
+                    "e": build_dummy_array(len(vec), np.float64),
+                }
+            )
+        )
+    else:
+        clsid = awkward.unflatten(ypred["cls_id"], cs)
+        msk = clsid != 0
+        p4 = awkward.unflatten(ypred["p4"], cs)
+
+        vec = vector.awk(
+            awkward.zip(
+                {
+                    "pt": p4[msk][:, :, 0],
+                    "eta": p4[msk][:, :, 1],
+                    "phi": p4[msk][:, :, 2],
+                    "e": p4[msk][:, :, 3],
+                }
+            )
+        )
+
+    cluster = fastjet.ClusterSequence(vec.to_xyzt(), jetdef)
+    jets_coll["pred"] = cluster.inclusive_jets(min_pt=jet_ptcut)
+
+    gen_to_pred = match_two_jet_collections(jets_coll, "gen", "pred", jet_match_dr)
+    gen_to_cand = match_two_jet_collections(jets_coll, "gen", "cand", jet_match_dr)
+
+    matched_jets = awkward.Array({"gen_to_pred": gen_to_pred, "gen_to_cand": gen_to_cand})
+
+    awkvals = {
+        "gen": awkward.from_iter([{k: ygen[k][batch_ids == b] for k in ygen.keys()} for b in np.unique(batch_ids)]),
+        "cand": awkward.from_iter([{k: ycand[k][batch_ids == b] for k in ycand.keys()} for b in np.unique(batch_ids)]),
+        "pred": awkward.from_iter([{k: ypred[k][batch_ids == b] for k in ypred.keys()} for b in np.unique(batch_ids)]),
+    }
+
+    awkward.to_parquet(
+        awkward.Array(
+            {
+                "inputs": Xs,
+                "particles": awkvals,
+                "jets": jets_coll,
+                "matched_jets": matched_jets,
+            }
+        ),
+        f"{outpath}/preds{dir_name}/{sample}/pred_{rank}_{i}.parquet",
+    )
+    _logger.info(f"Saved predictions at {outpath}/preds{dir_name}/{sample}/pred_{rank}_{i}.parquet")
+
+
 @torch.no_grad()
-def run_predictions(world_size, rank, model, loader, sample, outpath, jetdef, jet_ptcut=5.0, jet_match_dr=0.1, dir_name=""):
+def run_predictions(world_size, rank, model, loader, sample, outpath, jetdef, jet_ptcut=15.0, jet_match_dr=0.1, dir_name=""):
     """Runs inference on the given sample and stores the output as .parquet files."""
     if world_size > 1:
         conv_type = model.module.conv_type
@@ -46,112 +148,7 @@ def run_predictions(world_size, rank, model, loader, sample, outpath, jetdef, je
 
     ti = time.time()
     for i, batch in iterator:
-        if conv_type != "gravnet":
-            X_pad, mask = torch_geometric.utils.to_dense_batch(batch.X, batch.batch)
-            batch_pad = Batch(X=X_pad, mask=mask).to(rank)
-            ypred = model(batch_pad.X, batch_pad.mask)
-            ypred = ypred[0][mask], ypred[1][mask], ypred[2][mask]
-        else:
-            _batch = batch.to(rank)
-            ypred = model(_batch.X, _batch.batch)
-
-        ygen = unpack_target(batch.ygen)
-        ycand = unpack_target(batch.ycand)
-        ypred = unpack_predictions(ypred)
-
-        for k, v in ygen.items():
-            ygen[k] = v.detach().cpu()
-        for k, v in ycand.items():
-            ycand[k] = v.detach().cpu()
-        for k, v in ypred.items():
-            ypred[k] = v.detach().cpu()
-
-        # loop over the batch to disentangle the events
-        batch_ids = batch.batch.cpu().numpy()
-
-        jets_coll = {}
-        Xs, p4s = [], {"gen": [], "cand": [], "pred": []}
-        for _ibatch in np.unique(batch_ids):
-            msk_batch = batch_ids == _ibatch
-
-            Xs.append(batch.X[msk_batch].cpu().numpy())
-
-            # mask nulls for jet reconstruction
-            msk = (ygen["cls_id"][msk_batch] != 0).numpy()
-            p4s["gen"].append(ygen["p4"][msk_batch][msk].numpy())
-
-            msk = (ycand["cls_id"][msk_batch] != 0).numpy()
-            p4s["cand"].append(ycand["p4"][msk_batch][msk].numpy())
-
-            msk = (ypred["cls_id"][msk_batch] != 0).numpy()
-            p4s["pred"].append(ypred["p4"][msk_batch][msk].numpy())
-
-        Xs = awkward.from_iter(Xs)
-
-        for typ in ["gen", "cand"]:
-            vec = vector.awk(
-                awkward.zip(
-                    {
-                        "pt": awkward.from_iter(p4s[typ])[:, :, 0],
-                        "eta": awkward.from_iter(p4s[typ])[:, :, 1],
-                        "phi": awkward.from_iter(p4s[typ])[:, :, 2],
-                        "e": awkward.from_iter(p4s[typ])[:, :, 3],
-                    }
-                )
-            )
-            cluster = fastjet.ClusterSequence(vec.to_xyzt(), jetdef)
-            jets_coll[typ] = cluster.inclusive_jets(min_pt=jet_ptcut)
-
-        # in case of no predicted particles in the batch
-        if torch.sum(ypred["cls_id"] != 0) == 0:
-            vec = vector.awk(
-                awkward.zip(
-                    {
-                        "pt": build_dummy_array(len(p4s["pred"]), np.float64),
-                        "eta": build_dummy_array(len(p4s["pred"]), np.float64),
-                        "phi": build_dummy_array(len(p4s["pred"]), np.float64),
-                        "e": build_dummy_array(len(p4s["pred"]), np.float64),
-                    }
-                )
-            )
-        else:
-            vec = vector.awk(
-                awkward.zip(
-                    {
-                        "pt": awkward.from_iter(p4s["pred"])[:, :, 0],
-                        "eta": awkward.from_iter(p4s["pred"])[:, :, 1],
-                        "phi": awkward.from_iter(p4s["pred"])[:, :, 2],
-                        "e": awkward.from_iter(p4s["pred"])[:, :, 3],
-                    }
-                )
-            )
-
-        cluster = fastjet.ClusterSequence(vec.to_xyzt(), jetdef)
-        jets_coll["pred"] = cluster.inclusive_jets(min_pt=jet_ptcut)
-
-        gen_to_pred = match_two_jet_collections(jets_coll, "gen", "pred", jet_match_dr)
-        gen_to_cand = match_two_jet_collections(jets_coll, "gen", "cand", jet_match_dr)
-
-        matched_jets = awkward.Array({"gen_to_pred": gen_to_pred, "gen_to_cand": gen_to_cand})
-
-        awkvals = {
-            "gen": awkward.from_iter([{k: ygen[k][batch_ids == b] for k in ygen.keys()} for b in np.unique(batch_ids)]),
-            "cand": awkward.from_iter([{k: ycand[k][batch_ids == b] for k in ycand.keys()} for b in np.unique(batch_ids)]),
-            "pred": awkward.from_iter([{k: ypred[k][batch_ids == b] for k in ypred.keys()} for b in np.unique(batch_ids)]),
-        }
-
-        awkward.to_parquet(
-            awkward.Array(
-                {
-                    "inputs": Xs,
-                    "particles": awkvals,
-                    "jets": jets_coll,
-                    "matched_jets": matched_jets,
-                }
-            ),
-            f"{outpath}/preds{dir_name}/{sample}/pred_{rank}_{i}.parquet",
-        )
-        _logger.info(f"Saved predictions at {outpath}/preds{dir_name}/{sample}/pred_{rank}_{i}.parquet")
+        predict_one_batch(conv_type, model, i, batch, rank, jetdef, jet_ptcut, jet_match_dr, outpath, dir_name, sample)
 
     _logger.info(f"Time taken to make predictions on device {rank} is: {((time.time() - ti) / 60):.2f} min")
 

--- a/mlpf/pyg/mlpf.py
+++ b/mlpf/pyg/mlpf.py
@@ -42,7 +42,7 @@ class SelfAttentionLayer(nn.Module):
 
 
 class MambaLayer(nn.Module):
-    def __init__(self, embedding_dim=128, num_heads=2, width=128, dropout=0.1, d_state=16, d_conv=4, expand=2):
+    def __init__(self, embedding_dim=128, width=128, dropout=0.1, d_state=16, d_conv=4, expand=2):
         super(MambaLayer, self).__init__()
         self.act = nn.ELU
         from mamba_ssm import Mamba
@@ -144,8 +144,8 @@ class MLPF(nn.Module):
                 self.conv_id = nn.ModuleList()
                 self.conv_reg = nn.ModuleList()
                 for i in range(num_convs):
-                    self.conv_id.append(MambaLayer(embedding_dim, num_heads, width, dropout, d_state, d_conv, expand))
-                    self.conv_reg.append(MambaLayer(embedding_dim, num_heads, width, dropout, d_state, d_conv, expand))
+                    self.conv_id.append(MambaLayer(embedding_dim, width, dropout, d_state, d_conv, expand))
+                    self.conv_reg.append(MambaLayer(embedding_dim, width, dropout, d_state, d_conv, expand))
             elif self.conv_type == "gnn_lsh":
                 self.conv_id = nn.ModuleList()
                 self.conv_reg = nn.ModuleList()

--- a/mlpf/pyg/training.py
+++ b/mlpf/pyg/training.py
@@ -73,7 +73,7 @@ def mlpf_loss(y, ypred):
     loss_obj_id = FocalLoss(gamma=2.0, reduction="none")
 
     msk_true_particle = torch.unsqueeze((y["cls_id"] != 0).to(dtype=torch.float32), axis=-1)
-    npart = y["cls_id"].shape[0] * y["cls_id"].shape[1]
+    npart = y["pt"].numel()
 
     ypred["momentum"] = ypred["momentum"] * msk_true_particle
     ypred["charge"] = ypred["charge"] * msk_true_particle

--- a/mlpf/pyg/training.py
+++ b/mlpf/pyg/training.py
@@ -46,7 +46,21 @@ from utils import create_comet_experiment
 # Ignore divide by 0 errors
 np.seterr(divide="ignore", invalid="ignore")
 
-ISTEP_GLOBAL = 0
+
+def sliced_wasserstein_loss(y_true, y_pred, num_projections=200):
+    # create normalized random basis vectors
+    theta = torch.randn(num_projections, y_true.shape[-1]).to(device=y_true.device)
+    theta = theta / torch.sqrt(torch.sum(theta**2, axis=1, keepdims=True))
+
+    # project the features with the random basis
+    A = torch.matmul(y_true, torch.transpose(theta, -1, -2))
+    B = torch.matmul(y_pred, torch.transpose(theta, -1, -2))
+
+    A_sorted = torch.sort(A, axis=-2).values
+    B_sorted = torch.sort(B, axis=-2).values
+
+    ret = torch.sqrt(torch.sum(torch.pow(A_sorted - B_sorted, 2), axis=[-1, -2]))
+    return ret
 
 
 def mlpf_loss(y, ypred):
@@ -56,9 +70,10 @@ def mlpf_loss(y, ypred):
         ypred [dict]: relevant keys are "cls_id_onehot, momentum, charge"
     """
     loss = {}
-    loss_obj_id = FocalLoss(gamma=2.0)
+    loss_obj_id = FocalLoss(gamma=2.0, reduction="none")
 
     msk_true_particle = torch.unsqueeze((y["cls_id"] != 0).to(dtype=torch.float32), axis=-1)
+    npart = y["cls_id"].shape[0] * y["cls_id"].shape[1]
 
     ypred["momentum"] = ypred["momentum"] * msk_true_particle
     ypred["charge"] = ypred["charge"] * msk_true_particle
@@ -70,12 +85,37 @@ def mlpf_loss(y, ypred):
         ypred["cls_id_onehot"] = ypred["cls_id_onehot"].permute((0, 2, 1))
         ypred["charge"] = ypred["charge"].permute((0, 2, 1))
 
-    loss["Classification"] = 100 * loss_obj_id(ypred["cls_id_onehot"], y["cls_id"])
+    loss_classification = 100 * loss_obj_id(ypred["cls_id_onehot"], y["cls_id"]).reshape(y["cls_id"].shape)
+    loss_regression = 10 * torch.nn.functional.huber_loss(ypred["momentum"], y["momentum"], reduction="none")
+    loss_charge = torch.nn.functional.cross_entropy(ypred["charge"], y["charge"].to(dtype=torch.int64), reduction="none")
 
-    loss["Regression"] = 10 * torch.nn.functional.huber_loss(ypred["momentum"], y["momentum"])
-    loss["Charge"] = torch.nn.functional.cross_entropy(ypred["charge"], y["charge"].to(dtype=torch.int64))
+    loss["Classification"] = loss_classification.sum() / npart
+    loss["Regression"] = loss_regression.sum() / npart
+    loss["Charge"] = loss_charge.sum() / npart
+
+    # in case we are using the 3D-padded mode, we can compute a few additional event-level monitoring losses
+    if len(msk_true_particle.shape) == 3:
+        px = ypred["momentum"][..., 0:1] * ypred["momentum"][..., 3:4] * msk_true_particle
+        py = ypred["momentum"][..., 0:1] * ypred["momentum"][..., 2:3] * msk_true_particle
+        pred_met = torch.sqrt(torch.sum(px, axis=-2) ** 2 + torch.sum(py, axis=-2) ** 2)
+
+        px = y["momentum"][..., 0:1] * y["momentum"][..., 3:4] * msk_true_particle
+        py = y["momentum"][..., 0:1] * y["momentum"][..., 2:3] * msk_true_particle
+        true_met = torch.sqrt(torch.sum(px, axis=-2) ** 2 + torch.sum(py, axis=-2) ** 2)
+        loss["MET"] = torch.nn.functional.huber_loss(pred_met, true_met).detach().mean()
+        loss["Sliced_Wasserstein_Loss"] = sliced_wasserstein_loss(y["momentum"], ypred["momentum"]).detach().mean()
 
     loss["Total"] = loss["Classification"] + loss["Regression"] + loss["Charge"]
+
+    # Keep track of loss components for each true particle type
+    for icls in range(0, 7):
+        loss["cls{}_Classification".format(icls)] = (loss_classification[y["cls_id"] == icls].sum() / npart).detach()
+        loss["cls{}_Regression".format(icls)] = (loss_regression[y["cls_id"] == icls].sum() / npart).detach()
+
+    loss["Classification"] = loss["Classification"].detach()
+    loss["Regression"] = loss["Regression"].detach()
+    loss["Charge"] = loss["Charge"].detach()
+
     return loss
 
 
@@ -175,7 +215,7 @@ def train_and_valid(
     _logger.info(f"Initiating epoch #{epoch} {train_or_valid} run on device rank={rank}", color="red")
 
     # this one will keep accumulating `train_loss` and then return the average
-    epoch_loss = {"Total": 0.0, "Classification": 0.0, "Regression": 0.0, "Charge": 0.0}
+    epoch_loss = {}
 
     if is_train:
         model.train()
@@ -218,7 +258,9 @@ def train_and_valid(
             if lr_schedule:
                 lr_schedule.step()
 
-        for loss_ in epoch_loss:
+        for loss_ in loss.keys():
+            if loss_ not in epoch_loss:
+                epoch_loss[loss_] = 0.0
             epoch_loss[loss_] += loss[loss_].detach()
 
         if comet_experiment and is_train:

--- a/mlpf/pyg/utils.py
+++ b/mlpf/pyg/utils.py
@@ -135,6 +135,8 @@ def unpack_target(y):
         [ret["pt"].unsqueeze(1), ret["eta"].unsqueeze(1), ret["phi"].unsqueeze(1), ret["energy"].unsqueeze(1)], axis=1
     )
 
+    ret["genjet_idx"] = y[..., -1].long()
+
     return ret
 
 

--- a/parameters/pyg-cms.yaml
+++ b/parameters/pyg-cms.yaml
@@ -65,8 +65,6 @@ model:
     num_convs: 2
     dropout: 0.0
     activation: "elu"
-    # transformer specific paramters
-    num_heads: 2
     # mamba specific paramters
     d_state: 16
     d_conv: 4
@@ -178,38 +176,38 @@ test_dataset:
     physical:
       batch_size: 1
       samples:
-        cms_pf_ttbar:
-          version: 1.6.0
-        cms_pf_qcd:
-          version: 1.6.0
-        cms_pf_ztt:
-          version: 1.6.0
+        # cms_pf_ttbar:
+        #   version: 1.6.0
+        # cms_pf_qcd:
+        #   version: 1.6.0
+        # cms_pf_ztt:
+        #   version: 1.6.0
         cms_pf_qcd_high_pt:
           version: 1.6.0
-        cms_pf_sms_t1tttt:
-          version: 1.6.0
-    gun:
-      batch_size: 20
-      samples:
-        cms_pf_single_electron:
-          version: 1.6.0
-        cms_pf_single_gamma:
-          version: 1.6.0
-          batch_size: 20
-        cms_pf_single_pi0:
-          version: 1.6.0
-        cms_pf_single_neutron:
-          version: 1.6.0
-        cms_pf_single_pi:
-          version: 1.6.0
-        cms_pf_single_tau:
-          version: 1.6.0
-        cms_pf_single_mu:
-          version: 1.6.0
-        cms_pf_single_proton:
-          version: 1.6.0
-    multiparticlegun:
-      batch_size: 4
-      samples:
-        cms_pf_multi_particle_gun:
-          version: 1.6.0
+        # cms_pf_sms_t1tttt:
+        #   version: 1.6.0
+    # gun:
+    #   batch_size: 20
+    #   samples:
+    #     cms_pf_single_electron:
+    #       version: 1.6.0
+    #     cms_pf_single_gamma:
+    #       version: 1.6.0
+    #       batch_size: 20
+    #     cms_pf_single_pi0:
+    #       version: 1.6.0
+    #     cms_pf_single_neutron:
+    #       version: 1.6.0
+    #     cms_pf_single_pi:
+    #       version: 1.6.0
+    #     cms_pf_single_tau:
+    #       version: 1.6.0
+    #     cms_pf_single_mu:
+    #       version: 1.6.0
+    #     cms_pf_single_proton:
+    #       version: 1.6.0
+    # multiparticlegun:
+    #   batch_size: 4
+    #   samples:
+    #     cms_pf_multi_particle_gun:
+    #       version: 1.6.0


### PR DESCRIPTION
- speed up pytorch inference code by using more efficient awkward calls
- track individual loss components for each particle type
- track (but don't minimize) event-based losses like sliced Wasserstein and MET loss

Training the following mamba-based model:
```
singularity exec --nv ~/HEP-KBFI/singularity/pytorch.simg\:2023-12-06 python3 mlpf/pyg_pipeline.py --config parameters/pyg-cms.yaml --dataset cms --gpus 1 --data-dir ~/tensorflow_datasets/ --train --test --make-plots --conv-type mamba --num-epochs 5 --gpu-batch-multiplier 5 --num-workers 1 --prefetch-factor 10 --ntest 1000 --checkpoint-freq 1 --lr 0.001
```

![image](https://github.com/jpata/particleflow/assets/69717/d52119f2-e6f1-444a-aee8-5a2df50cd1c4)
![image](https://github.com/jpata/particleflow/assets/69717/8b087257-33e1-4c6a-8013-1fd379eadf0f)

we are also tracking (but not minimizing) these event-based losses
![image](https://github.com/jpata/particleflow/assets/69717/69a16d5b-1be3-49fe-972e-bcc2f3160fb5)

The performance on QCD-highpT is as follows:
![jet_res](https://github.com/jpata/particleflow/assets/69717/7bb20240-e6ca-4f3d-9120-54e56a4258e5)
![met_res](https://github.com/jpata/particleflow/assets/69717/e58ea3b0-8c4c-4af4-be9e-6e3c3b32130f)
