### PR TITLE
enable FlashAttention in pytorch, update to torch 2.2.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,8 @@ jobs:
           python-version: "3.10.12"
           cache: "pip"
       - run: pip install -r requirements.txt
-      - run: pip3 install torch==2.0.1 torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
-      - run: pip install pyg-lib torch-scatter torch-sparse torch-cluster torch-spline-conv torch-geometric -f https://data.pyg.org/whl/torch-2.0.1+cpu.html
+      - run: pip3 install torch==2.2.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
+      - run: pip install pyg_lib torch_scatter torch_sparse torch_cluster torch_spline_conv torch_geometric -f https://data.pyg.org/whl/torch-2.2.0+cpu.html
 
   tf-unittests:
     runs-on: ubuntu-22.04
@@ -101,8 +101,8 @@ jobs:
           python-version: "3.10.12"
           cache: "pip"
       - run: pip install -r requirements.txt
-      - run: pip3 install torch==2.0.1 torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
-      - run: pip install pyg-lib torch-scatter torch-sparse torch-cluster torch-spline-conv torch-geometric -f https://data.pyg.org/whl/torch-2.0.1+cpu.html
+      - run: pip3 install torch==2.2.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
+      - run: pip install pyg_lib torch_scatter torch_sparse torch_cluster torch_spline_conv torch_geometric -f https://data.pyg.org/whl/torch-2.2.0+cpu.html
       - run: PYTHONPATH=. python3 -m unittest tests/test_torch_and_tf.py
 
   pyg-pipeline:
@@ -115,6 +115,6 @@ jobs:
           python-version: "3.10.12"
           cache: "pip"
       - run: pip install -r requirements.txt
-      - run: pip3 install torch==2.0.1 torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
-      - run: pip install pyg-lib torch-scatter torch-sparse torch-cluster torch-spline-conv torch-geometric -f https://data.pyg.org/whl/torch-2.0.1+cpu.html
+      - run: pip3 install torch==2.2.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
+      - run: pip install pyg_lib torch_scatter torch_sparse torch_cluster torch_spline_conv torch_geometric -f https://data.pyg.org/whl/torch-2.2.0+cpu.html
       - run: ./scripts/local_test_pyg.sh

--- a/mlpf/pyg/PFDataset.py
+++ b/mlpf/pyg/PFDataset.py
@@ -106,11 +106,10 @@ class PFDataLoader(torch.utils.data.DataLoader):
 class Collater:
     """Based on the Collater found on torch_geometric docs we build our own."""
 
-    def __init__(self, keys_to_get, follow_batch=None, exclude_keys=None, pad_bin_size=640, pad_3d=True):
+    def __init__(self, keys_to_get, follow_batch=None, exclude_keys=None, pad_3d=True):
         self.follow_batch = follow_batch
         self.exclude_keys = exclude_keys
         self.keys_to_get = keys_to_get
-        self.pad_bin_size = pad_bin_size
         self.pad_3d = pad_3d
 
     def __call__(self, inputs):

--- a/mlpf/pyg/PFDataset.py
+++ b/mlpf/pyg/PFDataset.py
@@ -103,14 +103,19 @@ class PFDataLoader(torch.utils.data.DataLoader):
         )
 
 
+def next_power_of_2(x):
+    return 1 if x == 0 else 2 ** (x - 1).bit_length()
+
+
 class Collater:
     """Based on the Collater found on torch_geometric docs we build our own."""
 
-    def __init__(self, keys_to_get, follow_batch=None, exclude_keys=None, pad_3d=True):
+    def __init__(self, keys_to_get, follow_batch=None, exclude_keys=None, pad_3d=True, pad_power_of_two=True):
         self.follow_batch = follow_batch
         self.exclude_keys = exclude_keys
         self.keys_to_get = keys_to_get
         self.pad_3d = pad_3d
+        self.pad_power_of_two = False
 
     def __call__(self, inputs):
         num_samples_in_batch = len(inputs)
@@ -128,7 +133,16 @@ class Collater:
         if not self.pad_3d:
             return ret
         else:
-            ret = {k: torch_geometric.utils.to_dense_batch(getattr(ret, k), ret.batch) for k in elem_keys}
+            # pad to closest power of two
+            if self.pad_power_of_two:
+                sizes = [next_power_of_2(len(b.X)) for b in batch]
+                max_size = max(sizes)
+            else:
+                max_size = None
+            ret = {
+                k: torch_geometric.utils.to_dense_batch(getattr(ret, k), ret.batch, max_num_nodes=max_size)
+                for k in elem_keys
+            }
 
             ret["mask"] = ret["X"][1]
 
@@ -184,7 +198,7 @@ class InterleavedIterator(object):
             return len_
 
 
-def get_interleaved_dataloaders(world_size, rank, config, use_cuda, pad_3d, use_ray):
+def get_interleaved_dataloaders(world_size, rank, config, use_cuda, pad_3d, pad_power_of_two, use_ray):
     loaders = {}
     for split in ["train", "valid"]:  # build train, valid dataset and dataloaders
         loaders[split] = []
@@ -218,7 +232,7 @@ def get_interleaved_dataloaders(world_size, rank, config, use_cuda, pad_3d, use_
             loader = PFDataLoader(
                 dataset,
                 batch_size=batch_size,
-                collate_fn=Collater(["X", "ygen"], pad_3d=pad_3d),
+                collate_fn=Collater(["X", "ygen"], pad_3d=pad_3d, pad_power_of_two=pad_power_of_two),
                 sampler=sampler,
                 num_workers=config["num_workers"],
                 prefetch_factor=config["prefetch_factor"],

--- a/mlpf/pyg/inference.py
+++ b/mlpf/pyg/inference.py
@@ -7,7 +7,6 @@ import fastjet
 import mplhep
 import numpy as np
 import torch
-import torch_geometric
 import tqdm
 import vector
 from jet_utils import build_dummy_array, match_two_jet_collections
@@ -22,6 +21,7 @@ from plotting.plot_utils import (
     plot_particles,
     plot_sum_energy,
 )
+import torch_geometric
 from torch_geometric.data import Batch
 
 from .logger import _logger

--- a/mlpf/pyg/mlpf.py
+++ b/mlpf/pyg/mlpf.py
@@ -238,6 +238,7 @@ class MLPF(nn.Module):
         # elementwise DNN for node charge regression, classes (-1, 0, 1)
         self.nn_charge = ffn(decoding_dim + num_classes, 3, width, self.act, dropout)
 
+    # @torch.compile
     def forward(self, X_features, batch_or_mask):
         embeddings_id, embeddings_reg = [], []
         if self.num_convs != 0:

--- a/mlpf/pyg/training.py
+++ b/mlpf/pyg/training.py
@@ -243,7 +243,7 @@ def train_and_valid(
 
         batchidx_or_mask = batch.batch if conv_type == "gravnet" else batch.mask
 
-        with torch.autocast(device_type="cuda", dtype=dtype):
+        with torch.autocast(device_type=rank, dtype=dtype):
             if is_train:
                 ypred = model(batch.X, batchidx_or_mask)
             else:
@@ -252,7 +252,7 @@ def train_and_valid(
 
         ypred = unpack_predictions(ypred)
 
-        with torch.autocast(device_type="cuda", dtype=dtype):
+        with torch.autocast(device_type=rank, dtype=dtype):
             if is_train:
                 loss = mlpf_loss(ygen, ypred)
                 for param in model.parameters():
@@ -692,7 +692,7 @@ def run(rank, world_size, config, args, outdir, logfile):
                 else:
                     jetdef = fastjet.JetDefinition(fastjet.antikt_algorithm, 0.4)
 
-                with torch.autocast(device_type="cuda", dtype=dtype):
+                with torch.autocast(device_type=rank, dtype=dtype):
                     run_predictions(
                         world_size,
                         rank,

--- a/mlpf/pyg_pipeline.py
+++ b/mlpf/pyg_pipeline.py
@@ -84,6 +84,7 @@ def main():
 
     # override some options for the pipeline test
     if args.pipeline:
+        config["model"]["attention"]["attention_type"] = "math"
         if config["dataset"] == "cms":
             for ds in ["train_dataset", "test_dataset", "valid_dataset"]:
                 config[ds]["cms"] = {

--- a/mlpf/pyg_pipeline.py
+++ b/mlpf/pyg_pipeline.py
@@ -71,6 +71,20 @@ parser.add_argument("--comet-offline", action="store_true", help="save comet log
 parser.add_argument("--comet-step-freq", type=int, default=None, help="step frequency for saving comet metrics")
 parser.add_argument("--experiments-dir", type=str, default=None, help="base directory within which trainings are stored")
 parser.add_argument("--pipeline", action="store_true", default=None, help="test is running in pipeline")
+parser.add_argument(
+    "--dtype",
+    type=str,
+    default=None,
+    help="data type for training",
+    choices=["float32", "float16", "bfloat16"],
+)
+parser.add_argument(
+    "--attention-type",
+    type=str,
+    default=None,
+    help="attention type for self-attention layer",
+    choices=["math", "efficient", "flash"],
+)
 
 
 def main():
@@ -84,7 +98,6 @@ def main():
 
     # override some options for the pipeline test
     if args.pipeline:
-        config["model"]["attention"]["attention_type"] = "math"
         if config["dataset"] == "cms":
             for ds in ["train_dataset", "test_dataset", "valid_dataset"]:
                 config[ds]["cms"] = {

--- a/parameters/pytorch/pyg-clic-hits.yaml
+++ b/parameters/pytorch/pyg-clic-hits.yaml
@@ -19,6 +19,7 @@ checkpoint_freq:
 comet_name: particleflow-pt
 comet_offline: False
 comet_step_freq: 10
+dtype: float32
 
 model:
   pt_mode: linear
@@ -63,6 +64,7 @@ model:
     activation: "elu"
     # attention specific paramters
     num_heads: 2
+    attention_type: flash
 
   mamba:
     conv_type: mamba

--- a/parameters/pytorch/pyg-clic.yaml
+++ b/parameters/pytorch/pyg-clic.yaml
@@ -20,6 +20,7 @@ checkpoint_freq:
 comet_name: particleflow-pt
 comet_offline: False
 comet_step_freq: 10
+dtype: float32
 
 model:
   pt_mode: linear
@@ -64,6 +65,7 @@ model:
     activation: "elu"
     # attention specific paramters
     num_heads: 2
+    attention_type: flash
 
   mamba:
     conv_type: mamba

--- a/parameters/pytorch/pyg-cms.yaml
+++ b/parameters/pytorch/pyg-cms.yaml
@@ -20,7 +20,7 @@ checkpoint_freq:
 comet_name: particleflow-pt
 comet_offline: False
 comet_step_freq: 10
-dtype: float32
+dtype: bfloat16
 
 model:
   pt_mode: linear

--- a/parameters/pytorch/pyg-cms.yaml
+++ b/parameters/pytorch/pyg-cms.yaml
@@ -6,7 +6,7 @@ data_dir:
 gpus: 1
 gpu_batch_multiplier: 1
 load:
-num_epochs: 20
+num_epochs: 10
 patience: 20
 lr: 0.0005
 lr_schedule: cosinedecay  # constant, cosinedecay, onecycle
@@ -58,10 +58,10 @@ model:
 
   attention:
     conv_type: attention
-    embedding_dim: 512
-    width: 512
+    embedding_dim: 256
+    width: 256
     num_convs: 3
-    dropout: 0.1
+    dropout: 0.3
     activation: "elu"
     # attention specific paramters
     num_heads: 16

--- a/parameters/pytorch/pyg-cms.yaml
+++ b/parameters/pytorch/pyg-cms.yaml
@@ -20,6 +20,7 @@ checkpoint_freq:
 comet_name: particleflow-pt
 comet_offline: False
 comet_step_freq: 10
+dtype: float32
 
 model:
   pt_mode: linear
@@ -64,6 +65,7 @@ model:
     activation: "elu"
     # attention specific paramters
     num_heads: 2
+    attention_type: flash
 
   mamba:
     conv_type: mamba

--- a/parameters/pytorch/pyg-cms.yaml
+++ b/parameters/pytorch/pyg-cms.yaml
@@ -6,9 +6,9 @@ data_dir:
 gpus: 1
 gpu_batch_multiplier: 1
 load:
-num_epochs: 50
+num_epochs: 20
 patience: 20
-lr: 0.001
+lr: 0.0005
 lr_schedule: cosinedecay  # constant, cosinedecay, onecycle
 conv_type: gnn_lsh
 ntrain:
@@ -58,13 +58,13 @@ model:
 
   attention:
     conv_type: attention
-    embedding_dim: 256
-    width: 256
+    embedding_dim: 512
+    width: 512
     num_convs: 3
-    dropout: 0.0
+    dropout: 0.1
     activation: "elu"
     # attention specific paramters
-    num_heads: 2
+    num_heads: 16
     attention_type: flash
 
   mamba:

--- a/parameters/pytorch/pyg-delphes.yaml
+++ b/parameters/pytorch/pyg-delphes.yaml
@@ -20,6 +20,7 @@ checkpoint_freq:
 comet_name: particleflow-pt
 comet_offline: False
 comet_step_freq: 10
+dtype: float32
 
 model:
   pt_mode: linear
@@ -64,6 +65,7 @@ model:
     activation: "elu"
     # attention specific paramters
     num_heads: 2
+    attention_type: flash
 
   mamba:
     conv_type: mamba

--- a/scripts/local_test_pyg.sh
+++ b/scripts/local_test_pyg.sh
@@ -28,10 +28,10 @@ mkdir -p experiments
 tfds build mlpf/heptfds/cms_pf/ttbar --manual_dir ./local_test_data
 
 #test gravnet
-python mlpf/pyg_pipeline.py --config parameters/pytorch/pyg-cms.yaml --dataset cms --data-dir ./tensorflow_datasets/ --prefix MLPF_test_ --num-epochs 2 --nvalid 1 --gpus 0 --train --test --make-plots --conv-type gravnet --pipeline
+python mlpf/pyg_pipeline.py --config parameters/pytorch/pyg-cms.yaml --dataset cms --data-dir ./tensorflow_datasets/ --prefix MLPF_test_ --num-epochs 2 --nvalid 1 --gpus 0 --train --test --make-plots --conv-type gravnet --pipeline --dtype float32
 
 #test transformer
-python mlpf/pyg_pipeline.py --config parameters/pytorch/pyg-cms.yaml --dataset cms --data-dir ./tensorflow_datasets/ --prefix MLPF_test_ --num-epochs 2 --nvalid 1 --gpus 0 --train --test --make-plots --conv-type attention --pipeline
+python mlpf/pyg_pipeline.py --config parameters/pytorch/pyg-cms.yaml --dataset cms --data-dir ./tensorflow_datasets/ --prefix MLPF_test_ --num-epochs 2 --nvalid 1 --gpus 0 --train --test --make-plots --conv-type attention --pipeline --dtype float32 --attention-type math
 
 #test GNN-LSH with export
-python mlpf/pyg_pipeline.py --config parameters/pytorch/pyg-cms.yaml --dataset cms --data-dir ./tensorflow_datasets/ --prefix MLPF_test_ --num-epochs 2 --nvalid 1 --gpus 0 --train --test --make-plots --conv-type gnn_lsh --export-onnx --pipeline
+python mlpf/pyg_pipeline.py --config parameters/pytorch/pyg-cms.yaml --dataset cms --data-dir ./tensorflow_datasets/ --prefix MLPF_test_ --num-epochs 2 --nvalid 1 --gpus 0 --train --test --make-plots --conv-type gnn_lsh --export-onnx --pipeline --dtype float32

--- a/scripts/tallinn/a100/pytorch.sh
+++ b/scripts/tallinn/a100/pytorch.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 #SBATCH --partition gpu
 #SBATCH --gres gpu:a100:1
-#SBATCH --mem-per-gpu 40G
+#SBATCH --mem-per-gpu 80G
 #SBATCH -o logs/slurm-%x-%j-%N.out
 
-IMG=/home/software/singularity/pytorch.simg:2023-12-06
+IMG=/home/software/singularity/pytorch.simg:2024-02-05
 cd ~/particleflow
 
-#TF training
+#pytorch training
 singularity exec -B /scratch/persistent --nv \
     --env PYTHONPATH=hep_tfds \
     $IMG python3.10 mlpf/pyg_pipeline.py --dataset cms --gpus 1 \
     --data-dir /scratch/persistent/joosep/tensorflow_datasets --config parameters/pytorch/pyg-cms.yaml \
-    --train --conv-type attention --num-epochs 20 --gpu-batch-multiplier 20 --num-workers 1 --prefetch-factor 10
+    --train --conv-type attention --num-epochs 20 --gpu-batch-multiplier 20 --num-workers 2 --prefetch-factor 20
 #    --train --conv-type gnn_lsh --num-epochs 20 --gpu-batch-multiplier 4 --num-workers 1 --prefetch-factor 10 --ntrain 10000 --nvalid 10000
 #    --train --conv-type mamba --num-epochs 20 --gpu-batch-multiplier 10 --num-workers 1 --prefetch-factor 10 --ntrain 10000 --nvalid 10000
 

--- a/scripts/tallinn/a100/pytorch.sh
+++ b/scripts/tallinn/a100/pytorch.sh
@@ -12,6 +12,12 @@ singularity exec -B /scratch/persistent --nv \
     --env PYTHONPATH=hep_tfds \
     $IMG python3.10 mlpf/pyg_pipeline.py --dataset cms --gpus 1 \
     --data-dir /scratch/persistent/joosep/tensorflow_datasets --config parameters/pytorch/pyg-cms.yaml \
-    --train --conv-type attention --num-epochs 20 --gpu-batch-multiplier 10 --num-workers 1 --prefetch-factor 10 --ntrain 10000 --nvalid 10000
+    --train --conv-type attention --num-epochs 20 --gpu-batch-multiplier 20 --num-workers 1 --prefetch-factor 10
 #    --train --conv-type gnn_lsh --num-epochs 20 --gpu-batch-multiplier 4 --num-workers 1 --prefetch-factor 10 --ntrain 10000 --nvalid 10000
 #    --train --conv-type mamba --num-epochs 20 --gpu-batch-multiplier 10 --num-workers 1 --prefetch-factor 10 --ntrain 10000 --nvalid 10000
+
+# singularity exec -B /scratch/persistent --nv \
+#     --env PYTHONPATH=hep_tfds \
+#     $IMG python3.10 mlpf/pyg_pipeline.py --dataset cms --gpus 1 \
+#     --data-dir /scratch/persistent/joosep/tensorflow_datasets --config parameters/pytorch/pyg-cms.yaml \
+#     --test --make-plots --conv-type attention --gpu-batch-multiplier 10 --num-workers 1 --prefetch-factor 10 --load experiments/pyg-cms_20240204_183048_293390/sub1/best_weights.pth --ntest 1000

--- a/scripts/tallinn/a100/pytorch.sh
+++ b/scripts/tallinn/a100/pytorch.sh
@@ -12,5 +12,6 @@ singularity exec -B /scratch/persistent --nv \
     --env PYTHONPATH=hep_tfds \
     $IMG python3.10 mlpf/pyg_pipeline.py --dataset cms --gpus 1 \
     --data-dir /scratch/persistent/joosep/tensorflow_datasets --config parameters/pytorch/pyg-cms.yaml \
-    --train --conv-type gnn_lsh --num-epochs 20 --gpu-batch-multiplier 4 --num-workers 1 --prefetch-factor 10 --ntrain 10000 --nvalid 10000
+    --train --conv-type attention --num-epochs 20 --gpu-batch-multiplier 10 --num-workers 1 --prefetch-factor 10 --ntrain 10000 --nvalid 10000
+#    --train --conv-type gnn_lsh --num-epochs 20 --gpu-batch-multiplier 4 --num-workers 1 --prefetch-factor 10 --ntrain 10000 --nvalid 10000
 #    --train --conv-type mamba --num-epochs 20 --gpu-batch-multiplier 10 --num-workers 1 --prefetch-factor 10 --ntrain 10000 --nvalid 10000

--- a/scripts/tallinn/a100/pytorch.sh
+++ b/scripts/tallinn/a100/pytorch.sh
@@ -12,7 +12,7 @@ singularity exec -B /scratch/persistent --nv \
     --env PYTHONPATH=hep_tfds \
     $IMG python3.10 mlpf/pyg_pipeline.py --dataset cms --gpus 1 \
     --data-dir /scratch/persistent/joosep/tensorflow_datasets --config parameters/pytorch/pyg-cms.yaml \
-    --train --conv-type attention --num-epochs 20 --gpu-batch-multiplier 20 --num-workers 2 --prefetch-factor 20
+    --train --conv-type attention --num-epochs 10 --gpu-batch-multiplier 40 --num-workers 2 --prefetch-factor 20
 #    --train --conv-type gnn_lsh --num-epochs 20 --gpu-batch-multiplier 4 --num-workers 1 --prefetch-factor 10 --ntrain 10000 --nvalid 10000
 #    --train --conv-type mamba --num-epochs 20 --gpu-batch-multiplier 10 --num-workers 1 --prefetch-factor 10 --ntrain 10000 --nvalid 10000
 

--- a/scripts/tallinn/rtx/pytorch.sh
+++ b/scripts/tallinn/rtx/pytorch.sh
@@ -35,4 +35,4 @@ IMG=/home/software/singularity/pytorch.simg:2023-12-06
 #     --env PYTHONPATH=hep_tfds \
 #     $IMG python3.10 mlpf/pyg_pipeline.py --dataset cms --gpus 1 \
 #     --data-dir /scratch/persistent/joosep/tensorflow_datasets --config parameters/pytorch/pyg-cms.yaml \
-#     --test --make-plots --conv-type mamba --gpu-batch-multiplier 5 --num-workers 1 --prefetch-factor 10 --load experiments/pyg-cms_20240126_221457_189384/sub1/best_weights.pth --ntest 1000
+#     --test --make-plots --conv-type attention --gpu-batch-multiplier 10 --num-workers 1 --prefetch-factor 10 --load experiments/pyg-cms_20240204_183048_293390/sub1/best_weights.pth --ntest 1000


### PR DESCRIPTION
- update to torch 2.2.0 (it was transparent)
- make it possible to use FlashAttention via a config option (requires A100 or better)
- trained the CMS model on ~10% of data with 3 different options

![image](https://github.com/jpata/particleflow/assets/69717/a6ad0998-409a-4648-a690-fe27a53dc6de)
![image](https://github.com/jpata/particleflow/assets/69717/3d73a8fa-826a-4bcc-ae43-b93239b168d8)

The physics performance on the QCD high-pt sample is as follows.

Mamba (~98M):
![jet_res](https://github.com/jpata/particleflow/assets/69717/a9857986-1417-4459-9bff-69d355272fcc)
![met_res](https://github.com/jpata/particleflow/assets/69717/c9bf1610-afee-47a4-85bd-8552c77f06ad)

GNNLSH (~98M):
![jet_res](https://github.com/jpata/particleflow/assets/69717/98c9c5b4-6645-46d4-b6a2-b82afaea53b9)
![met_res](https://github.com/jpata/particleflow/assets/69717/44ea3511-301f-4894-ae6a-9c8edc07b54b)

FlashAttention (~4M):
![jet_res](https://github.com/jpata/particleflow/assets/69717/e4ab878d-c956-4702-b37c-5f4f97073eeb)
![met_res](https://github.com/jpata/particleflow/assets/69717/c62164f0-7317-4dc0-b937-e5333808d791)


Training on the full dataset for 10 epochs (`pyg-cms_20240208_214210_447656`), we get the following performance:
![jet_res](https://github.com/jpata/particleflow/assets/69717/20ff9d67-1b6a-4f79-86bd-63520a820e2a)
![met_res](https://github.com/jpata/particleflow/assets/69717/971a2110-053a-4b78-b6f3-1816c57e81d4)


