### PR TITLE
clean up loading

### DIFF
--- a/mlpf/data_cms/genjob_pu55to75.sh
+++ b/mlpf/data_cms/genjob_pu55to75.sh
@@ -24,15 +24,12 @@ PILEUP_INPUT=filelist:${MLPF_PATH}/mlpf/data_cms/pu_files_local.txt
 
 N=20
 
-env
 source /cvmfs/cms.cern.ch/cmsset_default.sh
 
 cd $CMSSWDIR
 eval `scramv1 runtime -sh`
 which python
 which python3
-
-env
 
 cd $WORKDIR
 

--- a/mlpf/data_cms/prepare_args.py
+++ b/mlpf/data_cms/prepare_args.py
@@ -6,26 +6,26 @@ import os
 outdir = "/local/joosep/mlpf/cms/v3"
 
 samples = [
-    ("TTbar_14TeV_TuneCUETP8M1_cfi",                           100000, 105010, "genjob_pu55to75.sh", outdir + "/pu55to75"),
-    ("ZTT_All_hadronic_14TeV_TuneCUETP8M1_cfi",                200000, 205010, "genjob_pu55to75.sh", outdir + "/pu55to75"),
-    ("QCDForPF_14TeV_TuneCUETP8M1_cfi",                        300000, 305010, "genjob_pu55to75.sh", outdir + "/pu55to75"),
-    ("QCD_Pt_3000_7000_14TeV_TuneCUETP8M1_cfi",                400000, 405010, "genjob_pu55to75.sh", outdir + "/pu55to75"),
-    ("SMS-T1tttt_mGl-1500_mLSP-100_TuneCP5_14TeV_pythia8_cfi", 500000, 505010, "genjob_pu55to75.sh", outdir + "/pu55to75"),
-    ("ZpTT_1500_14TeV_TuneCP5_cfi",                            600000, 605010, "genjob_pu55to75.sh", outdir + "/pu55to75"),
+#    ("TTbar_14TeV_TuneCUETP8M1_cfi",                           100000, 120010, "genjob_pu55to75.sh", outdir + "/pu55to75"),
+#    ("ZTT_All_hadronic_14TeV_TuneCUETP8M1_cfi",                200000, 220010, "genjob_pu55to75.sh", outdir + "/pu55to75"),
+    ("QCDForPF_14TeV_TuneCUETP8M1_cfi",                        300000, 320010, "genjob_pu55to75.sh", outdir + "/pu55to75"),
+#    ("QCD_Pt_3000_7000_14TeV_TuneCUETP8M1_cfi",                400000, 420010, "genjob_pu55to75.sh", outdir + "/pu55to75"),
+#    ("SMS-T1tttt_mGl-1500_mLSP-100_TuneCP5_14TeV_pythia8_cfi", 500000, 520010, "genjob_pu55to75.sh", outdir + "/pu55to75"),
+#    ("ZpTT_1500_14TeV_TuneCP5_cfi",                            600000, 620010, "genjob_pu55to75.sh", outdir + "/pu55to75"),
+#    ("VBF_TuneCP5_14TeV_pythia8_cfi",                         1700000,1720010, "genjob_pu55to75.sh", outdir + "/pu55to75"),
 
-    ("TTbar_14TeV_TuneCUETP8M1_cfi",                           700000, 701000, "genjob_nopu.sh", outdir + "/nopu"),
-    ("MultiParticlePFGun50_cfi",                               800000, 850000, "genjob_nopu.sh", outdir + "/nopu"),
-
-    ("SingleElectronFlatPt1To1000_pythia8_cfi",                900000, 910000, "genjob_nopu.sh", outdir + "/nopu"),
-    ("SingleGammaFlatPt1To1000_pythia8_cfi",                  1000000,1010000, "genjob_nopu.sh", outdir + "/nopu"),
-    ("SingleMuFlatPt1To1000_pythia8_cfi",                     1100000,1110000, "genjob_nopu.sh", outdir + "/nopu"),
-    ("SingleNeutronFlatPt0p7To1000_cfi",                      1200000,1210000, "genjob_nopu.sh", outdir + "/nopu"),
-    ("SinglePi0Pt1To1000_pythia8_cfi",                        1300000,1310000, "genjob_nopu.sh", outdir + "/nopu"),
-    ("SinglePiMinusFlatPt0p7To1000_cfi",                      1400000,1410000, "genjob_nopu.sh", outdir + "/nopu"),
-    ("SingleProtonMinusFlatPt0p7To1000_cfi",                  1500000,1510000, "genjob_nopu.sh", outdir + "/nopu"),
-    ("SingleTauFlatPt1To1000_cfi",                            1600000,1610000, "genjob_nopu.sh", outdir + "/nopu"),
-    
-    ("VBF_TuneCP5_14TeV_pythia8_cfi",                         1700000,1705010, "genjob_pu55to75.sh", outdir + "/pu55to75"),
+#     ("TTbar_14TeV_TuneCUETP8M1_cfi",                           700000, 701000, "genjob_nopu.sh", outdir + "/nopu"),
+#     ("MultiParticlePFGun50_cfi",                               800000, 850000, "genjob_nopu.sh", outdir + "/nopu"),
+# 
+#     ("SingleElectronFlatPt1To1000_pythia8_cfi",                900000, 910000, "genjob_nopu.sh", outdir + "/nopu"),
+#     ("SingleGammaFlatPt1To1000_pythia8_cfi",                  1000000,1010000, "genjob_nopu.sh", outdir + "/nopu"),
+#     ("SingleMuFlatPt1To1000_pythia8_cfi",                     1100000,1110000, "genjob_nopu.sh", outdir + "/nopu"),
+#     ("SingleNeutronFlatPt0p7To1000_cfi",                      1200000,1210000, "genjob_nopu.sh", outdir + "/nopu"),
+#     ("SinglePi0Pt1To1000_pythia8_cfi",                        1300000,1310000, "genjob_nopu.sh", outdir + "/nopu"),
+#     ("SinglePiMinusFlatPt0p7To1000_cfi",                      1400000,1410000, "genjob_nopu.sh", outdir + "/nopu"),
+#     ("SingleProtonMinusFlatPt0p7To1000_cfi",                  1500000,1510000, "genjob_nopu.sh", outdir + "/nopu"),
+#     ("SingleTauFlatPt1To1000_cfi",                            1600000,1610000, "genjob_nopu.sh", outdir + "/nopu"),
+#     
 ]
 
 if __name__ == "__main__":

--- a/mlpf/data_cms/prepare_args.py
+++ b/mlpf/data_cms/prepare_args.py
@@ -6,26 +6,25 @@ import os
 outdir = "/local/joosep/mlpf/cms/v3"
 
 samples = [
-#    ("TTbar_14TeV_TuneCUETP8M1_cfi",                           100000, 120010, "genjob_pu55to75.sh", outdir + "/pu55to75"),
-#    ("ZTT_All_hadronic_14TeV_TuneCUETP8M1_cfi",                200000, 220010, "genjob_pu55to75.sh", outdir + "/pu55to75"),
+    ("TTbar_14TeV_TuneCUETP8M1_cfi",                           100000, 120010, "genjob_pu55to75.sh", outdir + "/pu55to75"),
+    ("ZTT_All_hadronic_14TeV_TuneCUETP8M1_cfi",                200000, 220010, "genjob_pu55to75.sh", outdir + "/pu55to75"),
     ("QCDForPF_14TeV_TuneCUETP8M1_cfi",                        300000, 320010, "genjob_pu55to75.sh", outdir + "/pu55to75"),
-#    ("QCD_Pt_3000_7000_14TeV_TuneCUETP8M1_cfi",                400000, 420010, "genjob_pu55to75.sh", outdir + "/pu55to75"),
-#    ("SMS-T1tttt_mGl-1500_mLSP-100_TuneCP5_14TeV_pythia8_cfi", 500000, 520010, "genjob_pu55to75.sh", outdir + "/pu55to75"),
-#    ("ZpTT_1500_14TeV_TuneCP5_cfi",                            600000, 620010, "genjob_pu55to75.sh", outdir + "/pu55to75"),
-#    ("VBF_TuneCP5_14TeV_pythia8_cfi",                         1700000,1720010, "genjob_pu55to75.sh", outdir + "/pu55to75"),
+    ("QCD_Pt_3000_7000_14TeV_TuneCUETP8M1_cfi",                400000, 420010, "genjob_pu55to75.sh", outdir + "/pu55to75"),
+    ("SMS-T1tttt_mGl-1500_mLSP-100_TuneCP5_14TeV_pythia8_cfi", 500000, 520010, "genjob_pu55to75.sh", outdir + "/pu55to75"),
+    ("ZpTT_1500_14TeV_TuneCP5_cfi",                            600000, 620010, "genjob_pu55to75.sh", outdir + "/pu55to75"),
+    ("VBF_TuneCP5_14TeV_pythia8_cfi",                         1700000,1720010, "genjob_pu55to75.sh", outdir + "/pu55to75"),
 
-#     ("TTbar_14TeV_TuneCUETP8M1_cfi",                           700000, 701000, "genjob_nopu.sh", outdir + "/nopu"),
-#     ("MultiParticlePFGun50_cfi",                               800000, 850000, "genjob_nopu.sh", outdir + "/nopu"),
-# 
-#     ("SingleElectronFlatPt1To1000_pythia8_cfi",                900000, 910000, "genjob_nopu.sh", outdir + "/nopu"),
-#     ("SingleGammaFlatPt1To1000_pythia8_cfi",                  1000000,1010000, "genjob_nopu.sh", outdir + "/nopu"),
-#     ("SingleMuFlatPt1To1000_pythia8_cfi",                     1100000,1110000, "genjob_nopu.sh", outdir + "/nopu"),
-#     ("SingleNeutronFlatPt0p7To1000_cfi",                      1200000,1210000, "genjob_nopu.sh", outdir + "/nopu"),
-#     ("SinglePi0Pt1To1000_pythia8_cfi",                        1300000,1310000, "genjob_nopu.sh", outdir + "/nopu"),
-#     ("SinglePiMinusFlatPt0p7To1000_cfi",                      1400000,1410000, "genjob_nopu.sh", outdir + "/nopu"),
-#     ("SingleProtonMinusFlatPt0p7To1000_cfi",                  1500000,1510000, "genjob_nopu.sh", outdir + "/nopu"),
-#     ("SingleTauFlatPt1To1000_cfi",                            1600000,1610000, "genjob_nopu.sh", outdir + "/nopu"),
-#     
+    ("TTbar_14TeV_TuneCUETP8M1_cfi",                           700000, 701000, "genjob_nopu.sh", outdir + "/nopu"),
+    ("MultiParticlePFGun50_cfi",                               800000, 850000, "genjob_nopu.sh", outdir + "/nopu"),
+
+    ("SingleElectronFlatPt1To1000_pythia8_cfi",                900000, 910000, "genjob_nopu.sh", outdir + "/nopu"),
+    ("SingleGammaFlatPt1To1000_pythia8_cfi",                  1000000,1010000, "genjob_nopu.sh", outdir + "/nopu"),
+    ("SingleMuFlatPt1To1000_pythia8_cfi",                     1100000,1110000, "genjob_nopu.sh", outdir + "/nopu"),
+    ("SingleNeutronFlatPt0p7To1000_cfi",                      1200000,1210000, "genjob_nopu.sh", outdir + "/nopu"),
+    ("SinglePi0Pt1To1000_pythia8_cfi",                        1300000,1310000, "genjob_nopu.sh", outdir + "/nopu"),
+    ("SinglePiMinusFlatPt0p7To1000_cfi",                      1400000,1410000, "genjob_nopu.sh", outdir + "/nopu"),
+    ("SingleProtonMinusFlatPt0p7To1000_cfi",                  1500000,1510000, "genjob_nopu.sh", outdir + "/nopu"),
+    ("SingleTauFlatPt1To1000_cfi",                            1600000,1610000, "genjob_nopu.sh", outdir + "/nopu"),
 ]
 
 if __name__ == "__main__":

--- a/mlpf/heptfds/cms_pf/cms_utils.py
+++ b/mlpf/heptfds/cms_pf/cms_utils.py
@@ -152,18 +152,24 @@ def prepare_data_cms(fn, with_jet_idx=True):
             ygen["jet_idx"] = np.zeros(len(ygen["typ"]), dtype=np.float32)
             ycand["jet_idx"] = np.zeros(len(ycand["typ"]), dtype=np.float32)
 
-        Xelem_flat = ak.to_numpy(np.stack(
-            [Xelem[k] for k in X_FEATURES],
-            axis=-1,
-        ))
-        ygen_flat = ak.to_numpy(np.stack(
-            [ygen[k] for k in Y_FEATURES],
-            axis=-1,
-        ))
-        ycand_flat = ak.to_numpy(np.stack(
-            [ycand[k] for k in Y_FEATURES],
-            axis=-1,
-        ))
+        Xelem_flat = ak.to_numpy(
+            np.stack(
+                [Xelem[k] for k in X_FEATURES],
+                axis=-1,
+            )
+        )
+        ygen_flat = ak.to_numpy(
+            np.stack(
+                [ygen[k] for k in Y_FEATURES],
+                axis=-1,
+            )
+        )
+        ycand_flat = ak.to_numpy(
+            np.stack(
+                [ycand[k] for k in Y_FEATURES],
+                axis=-1,
+            )
+        )
 
         X = Xelem_flat
         ycand = ycand_flat

--- a/mlpf/heptfds/cms_pf/cms_utils.py
+++ b/mlpf/heptfds/cms_pf/cms_utils.py
@@ -6,7 +6,6 @@ import awkward as ak
 import fastjet
 import numpy as np
 import vector
-from numpy.lib.recfunctions import append_fields
 
 # https://github.com/ahlinist/cmssw/blob/1df62491f48ef964d198f574cdfcccfd17c70425/DataFormats/ParticleFlowReco/interface/PFBlockElement.h#L33
 ELEM_LABELS_CMS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
@@ -131,7 +130,7 @@ def prepare_data_cms(fn, with_jet_idx=True):
     elif fn.endswith(".pkl.bz2"):
         data = pickle.load(bz2.BZ2File(fn, "rb"))
 
-    for event in tqdm.tqdm(data):
+    for event in data:
         Xelem = event["Xelem"]
         ygen = event["ygen"]
         ycand = event["ycand"]
@@ -139,76 +138,32 @@ def prepare_data_cms(fn, with_jet_idx=True):
         # remove PS and BREM from inputs
         msk_ps = (Xelem["typ"] == 2) | (Xelem["typ"] == 3) | (Xelem["typ"] == 7)
 
-        Xelem = Xelem[~msk_ps]
-        ygen = ygen[~msk_ps]
-        ycand = ycand[~msk_ps]
+        Xelem = ak.Array(Xelem[~msk_ps])
+        ygen = ak.Array(ygen[~msk_ps])
+        ycand = ak.Array(ycand[~msk_ps])
 
-        Xelem = append_fields(
-            Xelem,
-            "sin_phi",
-            np.sin(Xelem["phi"]),
-        )
-        Xelem = append_fields(
-            Xelem,
-            "cos_phi",
-            np.cos(Xelem["phi"]),
-        )
+        Xelem["sin_phi"] = np.sin(Xelem["phi"])
+        Xelem["cos_phi"] = np.cos(Xelem["phi"])
+        Xelem["typ_idx"] = np.array([ELEM_LABELS_CMS.index(int(i)) for i in Xelem["typ"]], dtype=np.float32)
+        ygen["typ_idx"] = np.array([CLASS_LABELS_CMS.index(abs(int(i))) for i in ygen["typ"]], dtype=np.float32)
+        ycand["typ_idx"] = np.array([CLASS_LABELS_CMS.index(abs(int(i))) for i in ycand["typ"]], dtype=np.float32)
 
-        Xelem = append_fields(
-            Xelem,
-            "typ_idx",
-            np.array(
-                [ELEM_LABELS_CMS.index(int(i)) for i in Xelem["typ"]],
-                dtype=np.float32,
-            ),
-        )
-        ygen = append_fields(
-            ygen,
-            "typ_idx",
-            np.array(
-                [CLASS_LABELS_CMS.index(abs(int(i))) for i in ygen["typ"]],
-                dtype=np.float32,
-            ),
-        )
-        ycand = append_fields(
-            ycand,
-            "typ_idx",
-            np.array(
-                [CLASS_LABELS_CMS.index(abs(int(i))) for i in ycand["typ"]],
-                dtype=np.float32,
-            ),
-        )
-
-        y_features = Y_FEATURES[:-1]
         if with_jet_idx:
-            ygen = append_fields(ygen, "jet_idx", np.zeros(ygen["typ"].shape, dtype=np.float32))
-            ycand = append_fields(
-                ycand,
-                "jet_idx",
-                np.zeros(ycand["typ"].shape, dtype=np.float32),
-            )
-            y_features = Y_FEATURES
+            ygen["jet_idx"] = np.zeros(len(ygen["typ"]), dtype=np.float32)
+            ycand["jet_idx"] = np.zeros(len(ycand["typ"]), dtype=np.float32)
 
-        Xelem_flat = np.stack(
-            [Xelem[k].view(np.float32).data for k in X_FEATURES],
+        Xelem_flat = ak.to_numpy(np.stack(
+            [Xelem[k] for k in X_FEATURES],
             axis=-1,
-        )
-        ygen_flat = np.stack(
-            [ygen[k].view(np.float32).data for k in y_features],
+        ))
+        ygen_flat = ak.to_numpy(np.stack(
+            [ygen[k] for k in Y_FEATURES],
             axis=-1,
-        )
-        ycand_flat = np.stack(
-            [ycand[k].view(np.float32).data for k in y_features],
+        ))
+        ycand_flat = ak.to_numpy(np.stack(
+            [ycand[k] for k in Y_FEATURES],
             axis=-1,
-        )
-
-        # take care of outliers
-        # Xelem_flat[np.isnan(Xelem_flat)] = 0
-        # Xelem_flat[np.abs(Xelem_flat) > 1e4] = 0
-        # ygen_flat[np.isnan(ygen_flat)] = 0
-        # ygen_flat[np.abs(ygen_flat) > 1e4] = 0
-        # ycand_flat[np.isnan(ycand_flat)] = 0
-        # ycand_flat[np.abs(ycand_flat) > 1e4] = 0
+        ))
 
         X = Xelem_flat
         ycand = ycand_flat
@@ -224,13 +179,13 @@ def prepare_data_cms(fn, with_jet_idx=True):
             cumsum = np.cumsum(valid) - 1
             _, index_mapping = np.unique(cumsum, return_index=True)
 
-            pt = ygen[valid, y_features.index("pt")]
-            eta = ygen[valid, y_features.index("eta")]
+            pt = ygen[valid, Y_FEATURES.index("pt")]
+            eta = ygen[valid, Y_FEATURES.index("eta")]
             phi = np.arctan2(
-                ygen[valid, y_features.index("sin_phi")],
-                ygen[valid, y_features.index("cos_phi")],
+                ygen[valid, Y_FEATURES.index("sin_phi")],
+                ygen[valid, Y_FEATURES.index("cos_phi")],
             )
-            e = ygen[valid, y_features.index("e")]
+            e = ygen[valid, Y_FEATURES.index("e")]
             vec = vector.awk(ak.zip({"pt": pt, "eta": eta, "phi": phi, "e": e}))
 
             # cluster jets, sort jet indices in descending order by pt
@@ -249,8 +204,8 @@ def prepare_data_cms(fn, with_jet_idx=True):
                 jet_constituents = [
                     index_mapping[idx] for idx in constituent_idx[jet_idx]
                 ]  # map back to constituent index *before* masking
-                ygen[jet_constituents, y_features.index("jet_idx")] = jet_idx + 1  # jet index starts from 1
-                ycand[jet_constituents, y_features.index("jet_idx")] = jet_idx + 1
+                ygen[jet_constituents, Y_FEATURES.index("jet_idx")] = jet_idx + 1  # jet index starts from 1
+                ycand[jet_constituents, Y_FEATURES.index("jet_idx")] = jet_idx + 1
 
         Xs.append(X)
         ygens.append(ygen)

--- a/mlpf/heptfds/cms_pf/qcd.py
+++ b/mlpf/heptfds/cms_pf/qcd.py
@@ -21,7 +21,7 @@ _CITATION = """
 class CmsPfQcd(tfds.core.GeneratorBasedBuilder):
     """DatasetBuilder for cms_pf_qcd dataset."""
 
-    VERSION = tfds.core.Version("1.7.0")
+    VERSION = tfds.core.Version("1.7.1")
     RELEASE_NOTES = {
         "1.3.0": "12_2_0_pre2 generation with updated caloparticle/trackingparticle",
         "1.3.1": "Remove PS again",
@@ -30,6 +30,7 @@ class CmsPfQcd(tfds.core.GeneratorBasedBuilder):
         "1.5.1": "Remove outlier caps",
         "1.6.0": "Regenerate with ARRAY_RECORD",
         "1.7.0": "Add cluster shape vars",
+        "1.7.1": "Increase stats to 400k events",
     }
     MANUAL_DOWNLOAD_INSTRUCTIONS = """
     rsync -r --progress lxplus.cern.ch:/eos/user/j/jpata/mlpf/tensorflow_datasets/cms/cms_pf_qcd ~/tensorflow_datasets/

--- a/mlpf/heptfds/cms_pf/ttbar.py
+++ b/mlpf/heptfds/cms_pf/ttbar.py
@@ -21,7 +21,7 @@ _CITATION = """
 class CmsPfTtbar(tfds.core.GeneratorBasedBuilder):
     """DatasetBuilder for cms_pf dataset."""
 
-    VERSION = tfds.core.Version("1.7.0")
+    VERSION = tfds.core.Version("1.7.1")
     RELEASE_NOTES = {
         "1.0.0": "Initial release.",
         "1.1.0": "Add muon type, fix electron GSF association",
@@ -33,6 +33,7 @@ class CmsPfTtbar(tfds.core.GeneratorBasedBuilder):
         "1.5.1": "Remove outlier caps",
         "1.6.0": "Regenerate with ARRAY_RECORD",
         "1.7.0": "Add cluster shape vars",
+        "1.7.1": "Increase stats to 400k events",
     }
     MANUAL_DOWNLOAD_INSTRUCTIONS = """
     rsync -r --progress lxplus.cern.ch:/eos/user/j/jpata/mlpf/tensorflow_datasets/cms/cms_pf_ttbar ~/tensorflow_datasets/

--- a/mlpf/heptfds/cms_pf/ztt.py
+++ b/mlpf/heptfds/cms_pf/ztt.py
@@ -21,7 +21,7 @@ _CITATION = """
 class CmsPfZtt(tfds.core.GeneratorBasedBuilder):
     """DatasetBuilder for cms_pf_ztt dataset."""
 
-    VERSION = tfds.core.Version("1.7.0")
+    VERSION = tfds.core.Version("1.7.1")
     RELEASE_NOTES = {
         "1.3.0": "12_2_0_pre2 generation with updated caloparticle/trackingparticle",
         "1.3.1": "Remove PS again",
@@ -30,6 +30,7 @@ class CmsPfZtt(tfds.core.GeneratorBasedBuilder):
         "1.5.1": "Remove outlier caps",
         "1.6.0": "Regenerate with ARRAY_RECORD",
         "1.7.0": "Add cluster shape vars",
+        "1.7.1": "Increase stats to 400k events",
     }
     MANUAL_DOWNLOAD_INSTRUCTIONS = """
     rsync -r --progress lxplus.cern.ch:/eos/user/j/jpata/mlpf/tensorflow_datasets/cms/cms_pf_ztt ~/tensorflow_datasets/

--- a/mlpf/plotting/plot_utils.py
+++ b/mlpf/plotting/plot_utils.py
@@ -102,24 +102,18 @@ def get_class_names(sample_name):
     elif sample_name.startswith("delphes_"):
         return CLASS_NAMES_CLIC
     else:
-        raise Exception("Unknown dataset name: {}".format(dataset_name))
+        raise Exception("Unknown sample name: {}".format(sample_name))
+
 
 EVALUATION_DATASET_NAMES = {
     "delphes_ttbar_pf": r"Delphes-CMS $pp \rightarrow \mathrm{t}\overline{\mathrm{t}}$",
     "delphes_qcd_pf": r"Delphes-CMS $pp \rightarrow \mathrm{QCD}$",
-    "cms_pf_qcd_high_pt": r"CMS high-$p_T$ QCD+PU events",
-    "cms_pf_ttbar": r"CMS $\mathrm{t}\overline{\mathrm{t}}$+PU events",
-    "cms_pf_single_neutron": r"CMS single neutron particle gun events",
     "clic_edm_ttbar_pf": r"$e^+e^- \rightarrow \mathrm{t}\overline{\mathrm{t}}$",
     "clic_edm_ttbar_pu10_pf": r"$e^+e^- \rightarrow \mathrm{t}\overline{\mathrm{t}}$, PU10",
     "clic_edm_ttbar_hits_pf": r"$e^+e^- \rightarrow \mathrm{t}\overline{\mathrm{t}}$",
     "clic_edm_qq_pf": r"$e^+e^- \rightarrow \gamma/\mathrm{Z}^* \rightarrow \mathrm{hadrons}$",
     "clic_edm_ww_fullhad_pf": r"$e^+e^- \rightarrow WW \rightarrow \mathrm{hadrons}$",
     "clic_edm_zh_tautau_pf": r"$e^+e^- \rightarrow ZH \rightarrow \tau \tau$",
-
-    "delphes_ttbar_pf": r"Delphes-CMS $pp \rightarrow \mathrm{t}\overline{\mathrm{t}}$",
-    "delphes_qcd_pf": r"Delphes-CMS $pp \rightarrow \mathrm{QCD}$",
-
     "cms_pf_qcd": r"QCD $p_T \in [15, 3000]\ \mathrm{GeV}$+PU",
     "cms_pf_ztt": r"$\mathrm{Z}\rightarrow \mathrm{\tau}\mathrm{\tau}$+PU",
     "cms_pf_ttbar": r"$\mathrm{t}\overline{\mathrm{t}}$+PU",
@@ -209,11 +203,9 @@ def get_fake(df, pid):
     return v0 / len(df), np.sqrt(v0) / len(df)
 
 
-def experiment_label(ax,
-    experiment="CMS",
-    tag1="Simulation Preliminary",
-    tag2="Run 3 (14 TeV)",
-    x0=0.01, x1=0.15, x2=0.98, y=1.01):
+def experiment_label(
+    ax, experiment="CMS", tag1="Simulation Preliminary", tag2="Run 3 (14 TeV)", x0=0.01, x1=0.15, x2=0.98, y=1.01
+):
     plt.figtext(
         x0,
         y,
@@ -244,11 +236,14 @@ def experiment_label(ax,
         transform=ax.transAxes,
     )
 
+
 def cms_label(ax):
     return experiment_label(ax, experiment="CMS", tag1="Simulation Preliminary", tag2="Run 3 (14 TeV)")
 
+
 def clic_label(ax):
     return experiment_label(ax, experiment="Key4HEP-CLICdp", tag1="Simulation Preliminary", tag2="ee (380 GeV)")
+
 
 def delphes_label(ax):
     return experiment_label(ax, experiment="Delphes-CMS", tag1="Simulation Preliminary", tag2="pp (14 TeV)")
@@ -259,6 +254,7 @@ EXPERIMENT_LABELS = {
     "delphes": delphes_label,
     "clic": clic_label,
 }
+
 
 def sample_label(ax, sample, additional_text="", x=0.03, y=0.97):
     text = EVALUATION_DATASET_NAMES[sample]
@@ -449,8 +445,6 @@ def plot_jets(yvals, epoch=None, cp_dir=None, comet_experiment=None, title=None,
     b = np.logspace(1, 3, 100)
 
     pt = awkward.to_numpy(awkward.flatten(yvals["jets_cand_pt"]))
-    p = med_iqr(pt)
-    n = len(pt)
     plt.hist(
         pt,
         bins=b,
@@ -461,8 +455,6 @@ def plot_jets(yvals, epoch=None, cp_dir=None, comet_experiment=None, title=None,
     )
 
     pt = awkward.to_numpy(awkward.flatten(yvals["jets_pred_pt"]))
-    p = med_iqr(pt)
-    n = len(pt)
     plt.hist(
         pt,
         bins=b,
@@ -473,14 +465,12 @@ def plot_jets(yvals, epoch=None, cp_dir=None, comet_experiment=None, title=None,
     )
 
     pt = awkward.to_numpy(awkward.flatten(yvals["jets_gen_pt"]))
-    p = med_iqr(pt)
-    n = len(pt)
     plt.hist(
         pt,
         bins=b,
         histtype="step",
         lw=2,
-        #label="Gen $(M={:.2f}, IQR={:.2f}, N={})$".format(p[0], p[1], n),
+        # label="Gen $(M={:.2f}, IQR={:.2f}, N={})$".format(p[0], p[1], n),
         label="Truth",
     )
 
@@ -509,36 +499,29 @@ def plot_jets(yvals, epoch=None, cp_dir=None, comet_experiment=None, title=None,
         comet_experiment=comet_experiment,
     )
 
-
     plt.figure()
     b = np.linspace(0, 1000, 100)
     pt = awkward.to_numpy(awkward.flatten(yvals["jets_cand_pt"]))
-    p = med_iqr(pt)
-    n = len(pt)
     plt.hist(
         pt,
         bins=b,
         histtype="step",
         lw=2,
-        #label="PF $(M={:.2f}, IQR={:.2f}, N={})$".format(p[0], p[1], n),
+        # label="PF $(M={:.2f}, IQR={:.2f}, N={})$".format(p[0], p[1], n),
         label="PF",
     )
 
     pt = awkward.to_numpy(awkward.flatten(yvals["jets_pred_pt"]))
-    p = med_iqr(pt)
-    n = len(pt)
     plt.hist(
         pt,
         bins=b,
         histtype="step",
         lw=2,
-        #label="MLPF $(M={:.2f}, IQR={:.2f}, N={})$".format(p[0], p[1], n),
+        # label="MLPF $(M={:.2f}, IQR={:.2f}, N={})$".format(p[0], p[1], n),
         label="MLPF",
     )
 
     pt = awkward.to_numpy(awkward.flatten(yvals["jets_gen_pt"]))
-    p = med_iqr(pt)
-    n = len(pt)
     plt.hist(
         pt,
         bins=b,
@@ -570,9 +553,18 @@ def plot_jets(yvals, epoch=None, cp_dir=None, comet_experiment=None, title=None,
         comet_experiment=comet_experiment,
     )
 
+
 def plot_jet_ratio(
-    yvals, epoch=None, cp_dir=None, comet_experiment=None, title=None, bins=None, file_modifier="", logy=False,
-    dataset=None, sample=None
+    yvals,
+    epoch=None,
+    cp_dir=None,
+    comet_experiment=None,
+    title=None,
+    bins=None,
+    file_modifier="",
+    logy=False,
+    dataset=None,
+    sample=None,
 ):
     plt.figure()
     ax = plt.axes()
@@ -581,8 +573,6 @@ def plot_jet_ratio(
         bins = np.linspace(0, 5, 100)
 
     p = med_iqr(yvals["jet_ratio_cand"])
-    n_matched = len(yvals["jet_ratio_cand"])
-    n_jets = len(awkward.flatten(yvals["jets_cand_pt"]))
     plt.hist(
         yvals["jet_ratio_cand"],
         bins=bins,
@@ -591,7 +581,6 @@ def plot_jet_ratio(
         label="PF $({:.2f}\pm{:.2f})$".format(p[0], p[1]),
     )
     p = med_iqr(yvals["jet_ratio_pred"])
-    n_matched = len(yvals["jet_ratio_pred"])
     plt.hist(
         yvals["jet_ratio_pred"],
         bins=bins,
@@ -645,7 +634,6 @@ def plot_met(met_ratio, epoch=None, cp_dir=None, comet_experiment=None, title=No
 
     plt.figure()
     b = np.logspace(minval, maxval, 100)
-    p = med_iqr(met_ratio["cand_met"])
     plt.hist(
         met_ratio["cand_met"],
         bins=b,
@@ -654,7 +642,6 @@ def plot_met(met_ratio, epoch=None, cp_dir=None, comet_experiment=None, title=No
         # label="PF $(M={:.2f}, IQR={:.2f})$".format(p[0], p[1]),
         label="PF",
     )
-    p = med_iqr(met_ratio["pred_met"])
     plt.hist(
         met_ratio["pred_met"],
         bins=b,
@@ -663,7 +650,6 @@ def plot_met(met_ratio, epoch=None, cp_dir=None, comet_experiment=None, title=No
         # label="MLPF $(M={:.2f}, IQR={:.2f})$".format(p[0], p[1]),
         label="MLPF",
     )
-    p = med_iqr(met_ratio["gen_met"])
     plt.hist(
         met_ratio["gen_met"],
         bins=b,
@@ -689,33 +675,26 @@ def plot_met(met_ratio, epoch=None, cp_dir=None, comet_experiment=None, title=No
 
     save_img("met_log.png", epoch, cp_dir=cp_dir, comet_experiment=comet_experiment)
 
-
     b = np.linspace(0, 300, 100)
-    p = med_iqr(met_ratio["cand_met"])
     plt.hist(
         met_ratio["cand_met"],
         bins=b,
         histtype="step",
         lw=2,
-        # label="PF $(M={:.2f}, IQR={:.2f})$".format(p[0], p[1]),
         label="PF",
     )
-    p = med_iqr(met_ratio["pred_met"])
     plt.hist(
         met_ratio["pred_met"],
         bins=b,
         histtype="step",
         lw=2,
-        # label="MLPF $(M={:.2f}, IQR={:.2f})$".format(p[0], p[1]),
         label="MLPF",
     )
-    p = med_iqr(met_ratio["gen_met"])
     plt.hist(
         met_ratio["gen_met"],
         bins=b,
         histtype="step",
         lw=2,
-        # label="Truth $(M={:.2f}, IQR={:.2f})$".format(p[0], p[1]),
         label="Truth",
     )
     plt.xlabel(labels["met"])
@@ -734,8 +713,16 @@ def plot_met(met_ratio, epoch=None, cp_dir=None, comet_experiment=None, title=No
 
 
 def plot_met_ratio(
-    met_ratio, epoch=None, cp_dir=None, comet_experiment=None, title=None, bins=None, file_modifier="", logy=False,
-    sample=None, dataset=None
+    met_ratio,
+    epoch=None,
+    cp_dir=None,
+    comet_experiment=None,
+    title=None,
+    bins=None,
+    file_modifier="",
+    logy=False,
+    sample=None,
+    dataset=None,
 ):
     plt.figure()
     ax = plt.axes()
@@ -1044,31 +1031,25 @@ def plot_particles(yvals, epoch=None, cp_dir=None, comet_experiment=None, title=
     b = np.logspace(-1, 4, 100)
     plt.figure()
     ax = plt.gca()
-    p = med_iqr(cand_pt)
     plt.hist(
         cand_pt,
         bins=b,
         histtype="step",
         lw=2,
-        # label="PF $(M={:.2f}, IQR={:.2f})$".format(p[0], p[1]),
         label="PF",
     )
-    p = med_iqr(pred_pt)
     plt.hist(
         pred_pt,
         bins=b,
         histtype="step",
         lw=2,
-        # label="MLPF $(M={:.2f}, IQR={:.2f})$".format(p[0], p[1]),
         label="MLPF",
     )
-    p = med_iqr(gen_pt)
     plt.hist(
         gen_pt,
         bins=b,
         histtype="step",
         lw=2,
-        # label="Truth $(M={:.2f}, IQR={:.2f})$".format(p[0], p[1]),
         label="Truth",
     )
     plt.xscale("log")
@@ -1092,31 +1073,25 @@ def plot_particles(yvals, epoch=None, cp_dir=None, comet_experiment=None, title=
     b = np.linspace(0, 200, 100)
     plt.figure()
     ax = plt.gca()
-    p = med_iqr(cand_pt)
     plt.hist(
         cand_pt,
         bins=b,
         histtype="step",
         lw=2,
-        # label="PF $(M={:.2f}, IQR={:.2f})$".format(p[0], p[1]),
         label="PF",
     )
-    p = med_iqr(pred_pt)
     plt.hist(
         pred_pt,
         bins=b,
         histtype="step",
         lw=2,
-        # label="MLPF $(M={:.2f}, IQR={:.2f})$".format(p[0], p[1]),
         label="MLPF",
     )
-    p = med_iqr(gen_pt)
     plt.hist(
         gen_pt,
         bins=b,
         histtype="step",
         lw=2,
-        # label="Truth $(M={:.2f}, IQR={:.2f})$".format(p[0], p[1]),
         label="Truth",
     )
     plt.yscale("log")
@@ -1136,7 +1111,6 @@ def plot_particles(yvals, epoch=None, cp_dir=None, comet_experiment=None, title=
         comet_experiment=comet_experiment,
     )
 
-
     msk_cand = yvals["cand_cls_id"] != 0
     cand_pt = awkward.to_numpy(awkward.flatten(yvals["cand_eta"][msk_cand], axis=1))
 
@@ -1149,7 +1123,6 @@ def plot_particles(yvals, epoch=None, cp_dir=None, comet_experiment=None, title=
     b = np.linspace(-8, 8, 100)
     plt.figure()
     ax = plt.gca()
-    p = med_iqr(cand_pt)
     plt.hist(
         cand_pt,
         bins=b,
@@ -1157,7 +1130,6 @@ def plot_particles(yvals, epoch=None, cp_dir=None, comet_experiment=None, title=
         lw=2,
         label="PF",
     )
-    p = med_iqr(pred_pt)
     plt.hist(
         pred_pt,
         bins=b,
@@ -1165,7 +1137,6 @@ def plot_particles(yvals, epoch=None, cp_dir=None, comet_experiment=None, title=
         lw=2,
         label="MLPF",
     )
-    p = med_iqr(gen_pt)
     plt.hist(
         gen_pt,
         bins=b,
@@ -1404,7 +1375,9 @@ def plot_jet_response_binned(yvals, epoch=None, cp_dir=None, comet_experiment=No
     )
 
 
-def plot_jet_response_binned_eta(yvals, epoch=None, cp_dir=None, comet_experiment=None, title=None, sample=None, dataset=None):
+def plot_jet_response_binned_eta(
+    yvals, epoch=None, cp_dir=None, comet_experiment=None, title=None, sample=None, dataset=None
+):
     pf_genjet_eta = yvals["jet_gen_to_cand_geneta"]
     mlpf_genjet_eta = yvals["jet_gen_to_pred_geneta"]
 

--- a/mlpf/plotting/plot_utils.py
+++ b/mlpf/plotting/plot_utils.py
@@ -718,7 +718,7 @@ def plot_num_elements(X, epoch=None, cp_dir=None, comet_experiment=None, title=N
 
 
 def plot_sum_energy(yvals, class_names, epoch=None, cp_dir=None, comet_experiment=None, title=None):
-    cls_ids = np.unique(awkward.flatten(yvals["gen_cls_id"]))
+    cls_ids = np.unique(awkward.values_astype(awkward.flatten(yvals["gen_cls_id"]), np.int64))
 
     for cls_id in cls_ids:
         if cls_id == 0:
@@ -834,7 +834,7 @@ def plot_sum_energy(yvals, class_names, epoch=None, cp_dir=None, comet_experimen
 
 
 def plot_particle_multiplicity(X, yvals, class_names, epoch=None, cp_dir=None, comet_experiment=None, title=None):
-    cls_ids = np.unique(awkward.flatten(yvals["gen_cls_id"]))
+    cls_ids = np.unique(awkward.values_astype(awkward.flatten(yvals["gen_cls_id"]), np.int64))
 
     for cls_id in cls_ids:
         if cls_id == 0:

--- a/mlpf/plotting/plot_utils.py
+++ b/mlpf/plotting/plot_utils.py
@@ -437,8 +437,8 @@ def compute_3dmomentum_and_ratio(yvals):
 def save_img(outfile, epoch, cp_dir=None, comet_experiment=None):
     if cp_dir:
         image_path = str(cp_dir / outfile)
-        plt.savefig(image_path, dpi=100)
-        plt.savefig(image_path.replace(".png", ".pdf"))
+        plt.savefig(image_path, dpi=100, bbox_inches="tight")
+        plt.savefig(image_path.replace(".png", ".pdf"), bbox_inches="tight")
         plt.clf()
         if comet_experiment:
             comet_experiment.log_image(image_path, step=epoch - 1)

--- a/mlpf/plotting/plot_utils.py
+++ b/mlpf/plotting/plot_utils.py
@@ -79,31 +79,30 @@ CLASS_NAMES_CLIC = [
 
 labels = {
     "met": "$p_{\mathrm{T}}^{\mathrm{miss}}$ [GeV]",
-    "gen_met": "$p_{\mathrm{T,gen}}^\mathrm{miss}$ [GeV]",
-    "gen_mom": "$p_{\mathrm{gen}}$ [GeV]",
-    "gen_jet": "jet $p_{\mathrm{T,gen}}$ [GeV]",
-    "gen_jet_eta": "jet $\eta_{\mathrm{gen}}$ [GeV]",
+    "gen_met": "$p_{\mathrm{T,truth}}^\mathrm{miss}$ [GeV]",
+    "gen_mom": "$p_{\mathrm{truth}}$ [GeV]",
+    "gen_jet": "jet $p_{\mathrm{T,truth}}$ [GeV]",
+    "gen_jet_eta": "jet $\eta_{\mathrm{truth}}$ [GeV]",
     "reco_met": "$p_{\mathrm{T,reco}}^\mathrm{miss}$ [GeV]",
-    "reco_gen_met_ratio": "$p_{\mathrm{T,reco}}^\mathrm{miss} / p_{\\mathrm{T,gen}}^\mathrm{miss}$",
-    "reco_gen_mom_ratio": "$p_{\mathrm{reco}} / p_{\\mathrm{gen}}$",
-    "reco_gen_jet_ratio": "jet $p_{\mathrm{T,reco}} / p_{\\mathrm{T,gen}}$",
-    "gen_met_range": "${} \less p_{{\mathrm{{T,gen}}}}^\mathrm{{miss}}\leq {}$",
-    "gen_mom_range": "${} \less p_{{\mathrm{{gen}}}}\leq {}$",
-    "gen_jet_range": "${} \less p_{{\mathrm{{T,gen}}}} \leq {}$",
-    "gen_jet_range_eta": "${} \less \eta_{{\mathrm{{gen}}}} \leq {}$",
+    "reco_gen_met_ratio": "$p_{\mathrm{T,reco}}^\mathrm{miss} / p_{\\mathrm{T,truth}}^\mathrm{miss}$",
+    "reco_gen_mom_ratio": "$p_{\mathrm{reco}} / p_{\\mathrm{truth}}$",
+    "reco_gen_jet_ratio": "jet $p_{\mathrm{T,reco}} / p_{\\mathrm{T,truth}}$",
+    "gen_met_range": "${} \less p_{{\mathrm{{T,truth}}}}^\mathrm{{miss}}\leq {}$",
+    "gen_mom_range": "${} \less p_{{\mathrm{{truth}}}}\leq {}$",
+    "gen_jet_range": "${} \less p_{{\mathrm{{T,truth}}}} \leq {}$",
+    "gen_jet_range_eta": "${} \less \eta_{{\mathrm{{truth}}}} \leq {}$",
 }
 
 
-def get_class_names(dataset_name):
-    if dataset_name.startswith("clic_"):
+def get_class_names(sample_name):
+    if sample_name.startswith("clic_"):
         return CLASS_NAMES_CLIC
-    elif dataset_name.startswith("cms_"):
+    elif sample_name.startswith("cms_"):
         return CLASS_NAMES_CMS
-    elif dataset_name.startswith("delphes_"):
+    elif sample_name.startswith("delphes_"):
         return CLASS_NAMES_CLIC
     else:
         raise Exception("Unknown dataset name: {}".format(dataset_name))
-
 
 EVALUATION_DATASET_NAMES = {
     "delphes_ttbar_pf": r"Delphes-CMS $pp \rightarrow \mathrm{t}\overline{\mathrm{t}}$",
@@ -117,20 +116,22 @@ EVALUATION_DATASET_NAMES = {
     "clic_edm_qq_pf": r"$e^+e^- \rightarrow \gamma/\mathrm{Z}^* \rightarrow \mathrm{hadrons}$",
     "clic_edm_ww_fullhad_pf": r"$e^+e^- \rightarrow WW \rightarrow \mathrm{hadrons}$",
     "clic_edm_zh_tautau_pf": r"$e^+e^- \rightarrow ZH \rightarrow \tau \tau$",
-    # added by farouk
+
     "delphes_ttbar_pf": r"Delphes-CMS $pp \rightarrow \mathrm{t}\overline{\mathrm{t}}$",
     "delphes_qcd_pf": r"Delphes-CMS $pp \rightarrow \mathrm{QCD}$",
-    "cms_pf_qcd": r"CMS QCD+PU events",
-    "cms_pf_ztt": r"CMS Ztt events",
-    "cms_pf_multi_particle_gun": r"CMS multi particle gun events",
-    "cms_pf_single_electron": r"CMS single electron particle gun events",
-    "cms_pf_single_gamma": r"CMS single photon gun events",
-    "cms_pf_single_mu": r"CMS single muon particle gun events",
-    "cms_pf_single_pi": r"CMS single pion particle gun events",
-    "cms_pf_single_pi0": r"CMS single neutral pion particle gun events",
-    "cms_pf_single_proton": r"CMS single proton particle gun events",
-    "cms_pf_single_tau": r"CMS single tau particle gun events",
-    "cms_pf_sms_t1tttt": r"CMS sms t1tttt events",
+
+    "cms_pf_qcd": r"QCD $p_T \in [15, 3000]\ \mathrm{GeV}$+PU",
+    "cms_pf_ztt": r"$\mathrm{Z}\rightarrow \mathrm{\tau}\mathrm{\tau}$+PU",
+    "cms_pf_ttbar": r"$\mathrm{t}\overline{\mathrm{t}}$+PU",
+    "cms_pf_multi_particle_gun": r"multi particle gun events",
+    "cms_pf_single_electron": r"single electron particle gun events",
+    "cms_pf_single_gamma": r"single photon gun events",
+    "cms_pf_single_mu": r"single muon particle gun events",
+    "cms_pf_single_pi": r"single pion particle gun events",
+    "cms_pf_single_pi0": r"single neutral pion particle gun events",
+    "cms_pf_single_proton": r"single proton particle gun events",
+    "cms_pf_single_tau": r"single tau particle gun events",
+    "cms_pf_sms_t1tttt": r"sms t1tttt events",
 }
 
 
@@ -208,38 +209,60 @@ def get_fake(df, pid):
     return v0 / len(df), np.sqrt(v0) / len(df)
 
 
-def cms_label(ax, x0=0.01, x1=0.15, x2=0.98, y=0.94):
+def experiment_label(ax,
+    experiment="CMS",
+    tag1="Simulation Preliminary",
+    tag2="Run 3 (14 TeV)",
+    x0=0.01, x1=0.15, x2=0.98, y=1.01):
     plt.figtext(
         x0,
         y,
-        "CMS",
+        experiment,
         fontweight="bold",
         wrap=True,
         horizontalalignment="left",
+        verticalalignment="bottom",
         transform=ax.transAxes,
     )
     plt.figtext(
         x1,
         y,
-        "Simulation Preliminary",
+        tag1,
         style="italic",
         wrap=True,
         horizontalalignment="left",
+        verticalalignment="bottom",
         transform=ax.transAxes,
     )
     plt.figtext(
         x2,
         y,
-        "Run 3 (14 TeV)",
+        tag2,
         wrap=False,
         horizontalalignment="right",
+        verticalalignment="bottom",
         transform=ax.transAxes,
     )
 
+def cms_label(ax):
+    return experiment_label(ax, experiment="CMS", tag1="Simulation Preliminary", tag2="Run 3 (14 TeV)")
 
-def sample_label(ax, sample, additional_text="", x=0.01, y=0.87):
-    text = SAMPLE_LABEL_CMS[sample]
-    plt.text(x, y, text + additional_text, ha="left", transform=ax.transAxes)
+def clic_label(ax):
+    return experiment_label(ax, experiment="Key4HEP-CLICdp", tag1="Simulation Preliminary", tag2="ee (380 GeV)")
+
+def delphes_label(ax):
+    return experiment_label(ax, experiment="Delphes-CMS", tag1="Simulation Preliminary", tag2="pp (14 TeV)")
+
+
+EXPERIMENT_LABELS = {
+    "cms": cms_label,
+    "delphes": delphes_label,
+    "clic": clic_label,
+}
+
+def sample_label(ax, sample, additional_text="", x=0.03, y=0.97):
+    text = EVALUATION_DATASET_NAMES[sample]
+    plt.text(x, y, text + additional_text, ha="left", va="top", transform=ax.transAxes)
 
 
 def particle_label(ax, pid):
@@ -421,9 +444,9 @@ def save_img(outfile, epoch, cp_dir=None, comet_experiment=None):
             comet_experiment.log_image(image_path, step=epoch - 1)
 
 
-def plot_jets(yvals, epoch=None, cp_dir=None, comet_experiment=None, title=None):
+def plot_jets(yvals, epoch=None, cp_dir=None, comet_experiment=None, title=None, sample=None, dataset=None):
     plt.figure()
-    b = np.logspace(0, 3, 100)
+    b = np.logspace(1, 3, 100)
 
     pt = awkward.to_numpy(awkward.flatten(yvals["jets_cand_pt"]))
     p = med_iqr(pt)
@@ -433,7 +456,8 @@ def plot_jets(yvals, epoch=None, cp_dir=None, comet_experiment=None, title=None)
         bins=b,
         histtype="step",
         lw=2,
-        label="PF $(M={:.2f}, IQR={:.2f}, N={})$".format(p[0], p[1], n),
+        # label="PF $(M={:.2f}, IQR={:.2f}, N={})$".format(p[0], p[1], n),
+        label="PF",
     )
 
     pt = awkward.to_numpy(awkward.flatten(yvals["jets_pred_pt"]))
@@ -444,7 +468,8 @@ def plot_jets(yvals, epoch=None, cp_dir=None, comet_experiment=None, title=None)
         bins=b,
         histtype="step",
         lw=2,
-        label="MLPF $(M={:.2f}, IQR={:.2f}, N={})$".format(p[0], p[1], n),
+        # label="MLPF $(M={:.2f}, IQR={:.2f}, N={})$".format(p[0], p[1], n),
+        label="MLPF",
     )
 
     pt = awkward.to_numpy(awkward.flatten(yvals["jets_gen_pt"]))
@@ -455,7 +480,8 @@ def plot_jets(yvals, epoch=None, cp_dir=None, comet_experiment=None, title=None)
         bins=b,
         histtype="step",
         lw=2,
-        label="Gen $(M={:.2f}, IQR={:.2f}, N={})$".format(p[0], p[1], n),
+        #label="Gen $(M={:.2f}, IQR={:.2f}, N={})$".format(p[0], p[1], n),
+        label="Truth",
     )
 
     plt.xscale("log")
@@ -464,6 +490,79 @@ def plot_jets(yvals, epoch=None, cp_dir=None, comet_experiment=None, title=None)
     plt.legend(loc="best")
     if title:
         plt.title(title)
+
+    plt.yscale("log")
+    ax = plt.gca()
+    ylim = ax.get_ylim()
+    ax.set_ylim(ylim[0], 10 * ylim[1])
+
+    if dataset:
+        EXPERIMENT_LABELS[dataset](ax)
+
+    if sample:
+        sample_label(ax, sample)
+
+    save_img(
+        "jet_pt_log.png",
+        epoch,
+        cp_dir=cp_dir,
+        comet_experiment=comet_experiment,
+    )
+
+
+    plt.figure()
+    b = np.linspace(0, 1000, 100)
+    pt = awkward.to_numpy(awkward.flatten(yvals["jets_cand_pt"]))
+    p = med_iqr(pt)
+    n = len(pt)
+    plt.hist(
+        pt,
+        bins=b,
+        histtype="step",
+        lw=2,
+        #label="PF $(M={:.2f}, IQR={:.2f}, N={})$".format(p[0], p[1], n),
+        label="PF",
+    )
+
+    pt = awkward.to_numpy(awkward.flatten(yvals["jets_pred_pt"]))
+    p = med_iqr(pt)
+    n = len(pt)
+    plt.hist(
+        pt,
+        bins=b,
+        histtype="step",
+        lw=2,
+        #label="MLPF $(M={:.2f}, IQR={:.2f}, N={})$".format(p[0], p[1], n),
+        label="MLPF",
+    )
+
+    pt = awkward.to_numpy(awkward.flatten(yvals["jets_gen_pt"]))
+    p = med_iqr(pt)
+    n = len(pt)
+    plt.hist(
+        pt,
+        bins=b,
+        histtype="step",
+        lw=2,
+        # label="Gen $(M={:.2f}, IQR={:.2f}, N={})$".format(p[0], p[1], n),
+        label="Truth",
+    )
+
+    plt.xlabel("jet $p_T$")
+    plt.ylabel("Jets / bin")
+    plt.yscale("log")
+    plt.legend(loc="best")
+    if title:
+        plt.title(title)
+    ax = plt.gca()
+    ylim = ax.get_ylim()
+    ax.set_ylim(ylim[0], 10 * ylim[1])
+
+    if dataset:
+        EXPERIMENT_LABELS[dataset](ax)
+    if sample:
+        sample_label(ax, sample)
+
     save_img(
         "jet_pt.png",
         epoch,
@@ -471,9 +570,9 @@ def plot_jets(yvals, epoch=None, cp_dir=None, comet_experiment=None, title=None)
         comet_experiment=comet_experiment,
     )
 
-
 def plot_jet_ratio(
-    yvals, epoch=None, cp_dir=None, comet_experiment=None, title=None, bins=None, file_modifier="", logy=False
+    yvals, epoch=None, cp_dir=None, comet_experiment=None, title=None, bins=None, file_modifier="", logy=False,
+    dataset=None, sample=None
 ):
     plt.figure()
     ax = plt.axes()
@@ -489,7 +588,7 @@ def plot_jet_ratio(
         bins=bins,
         histtype="step",
         lw=2,
-        label="PF $(M={:.2f}, IQR={:.2f}, f_m={:.2f})$".format(p[0], p[1], n_matched / n_jets),
+        label="PF $({:.2f}\pm{:.2f})$".format(p[0], p[1]),
     )
     p = med_iqr(yvals["jet_ratio_pred"])
     n_matched = len(yvals["jet_ratio_pred"])
@@ -498,11 +597,16 @@ def plot_jet_ratio(
         bins=bins,
         histtype="step",
         lw=2,
-        label="MLPF $(M={:.2f}, IQR={:.2f}, f_m={:.2f})$".format(p[0], p[1], n_matched / n_jets),
+        label="MLPF $(M={:.2f}\pm{:.2f})$".format(p[0], p[1]),
     )
     plt.xlabel(labels["reco_gen_jet_ratio"])
     plt.ylabel("Matched jets / bin")
-    plt.legend(loc="best", title=title)
+    plt.legend(loc="best")
+
+    if dataset:
+        EXPERIMENT_LABELS[dataset](ax)
+    if sample:
+        sample_label(ax, sample)
 
     plt.ticklabel_format(axis="y", style="sci", scilimits=(0, 0))
 
@@ -521,8 +625,7 @@ def plot_jet_ratio(
     )
 
 
-def plot_met(met_ratio, epoch=None, cp_dir=None, comet_experiment=None, title=None):
-    plt.figure()
+def plot_met(met_ratio, epoch=None, cp_dir=None, comet_experiment=None, title=None, sample=None, dataset=None):
     maxval = max(
         [
             np.max(met_ratio["gen_met"]),
@@ -540,6 +643,7 @@ def plot_met(met_ratio, epoch=None, cp_dir=None, comet_experiment=None, title=No
     maxval = math.ceil(np.log10(maxval))
     minval = math.floor(np.log10(max(minval, 1e-2)))
 
+    plt.figure()
     b = np.logspace(minval, maxval, 100)
     p = med_iqr(met_ratio["cand_met"])
     plt.hist(
@@ -547,7 +651,8 @@ def plot_met(met_ratio, epoch=None, cp_dir=None, comet_experiment=None, title=No
         bins=b,
         histtype="step",
         lw=2,
-        label="PF $(M={:.2f}, IQR={:.2f})$".format(p[0], p[1]),
+        # label="PF $(M={:.2f}, IQR={:.2f})$".format(p[0], p[1]),
+        label="PF",
     )
     p = med_iqr(met_ratio["pred_met"])
     plt.hist(
@@ -555,7 +660,8 @@ def plot_met(met_ratio, epoch=None, cp_dir=None, comet_experiment=None, title=No
         bins=b,
         histtype="step",
         lw=2,
-        label="MLPF $(M={:.2f}, IQR={:.2f})$".format(p[0], p[1]),
+        # label="MLPF $(M={:.2f}, IQR={:.2f})$".format(p[0], p[1]),
+        label="MLPF",
     )
     p = med_iqr(met_ratio["gen_met"])
     plt.hist(
@@ -563,17 +669,73 @@ def plot_met(met_ratio, epoch=None, cp_dir=None, comet_experiment=None, title=No
         bins=b,
         histtype="step",
         lw=2,
-        label="Truth $(M={:.2f}, IQR={:.2f})$".format(p[0], p[1]),
+        # label="Truth $(M={:.2f}, IQR={:.2f})$".format(p[0], p[1]),
+        label="Truth",
     )
     plt.xlabel(labels["met"])
     plt.ylabel("Events / bin")
     plt.legend(loc="best", title=title)
     plt.xscale("log")
+    plt.yscale("log")
+
+    ax = plt.gca()
+    ylim = ax.get_ylim()
+    ax.set_ylim(ylim[0], 10 * ylim[1])
+
+    if dataset:
+        EXPERIMENT_LABELS[dataset](ax)
+    if sample:
+        sample_label(ax, sample)
+
+    save_img("met_log.png", epoch, cp_dir=cp_dir, comet_experiment=comet_experiment)
+
+
+    b = np.linspace(0, 300, 100)
+    p = med_iqr(met_ratio["cand_met"])
+    plt.hist(
+        met_ratio["cand_met"],
+        bins=b,
+        histtype="step",
+        lw=2,
+        # label="PF $(M={:.2f}, IQR={:.2f})$".format(p[0], p[1]),
+        label="PF",
+    )
+    p = med_iqr(met_ratio["pred_met"])
+    plt.hist(
+        met_ratio["pred_met"],
+        bins=b,
+        histtype="step",
+        lw=2,
+        # label="MLPF $(M={:.2f}, IQR={:.2f})$".format(p[0], p[1]),
+        label="MLPF",
+    )
+    p = med_iqr(met_ratio["gen_met"])
+    plt.hist(
+        met_ratio["gen_met"],
+        bins=b,
+        histtype="step",
+        lw=2,
+        # label="Truth $(M={:.2f}, IQR={:.2f})$".format(p[0], p[1]),
+        label="Truth",
+    )
+    plt.xlabel(labels["met"])
+    plt.ylabel("Events / bin")
+    plt.legend(loc="best", title=title)
+    plt.yscale("log")
+    ax = plt.gca()
+    ylim = ax.get_ylim()
+    ax.set_ylim(ylim[0], 10 * ylim[1])
+    if dataset:
+        EXPERIMENT_LABELS[dataset](ax)
+    if sample:
+        sample_label(ax, sample)
+
     save_img("met.png", epoch, cp_dir=cp_dir, comet_experiment=comet_experiment)
 
 
 def plot_met_ratio(
-    met_ratio, epoch=None, cp_dir=None, comet_experiment=None, title=None, bins=None, file_modifier="", logy=False
+    met_ratio, epoch=None, cp_dir=None, comet_experiment=None, title=None, bins=None, file_modifier="", logy=False,
+    sample=None, dataset=None
 ):
     plt.figure()
     ax = plt.axes()
@@ -606,6 +768,11 @@ def plot_met_ratio(
     if logy:
         ax.set_yscale("log")
         ax.set_ylim(10, 10 * ylim[1])
+
+    if dataset:
+        EXPERIMENT_LABELS[dataset](ax)
+    if sample:
+        sample_label(ax, sample)
 
     save_img(
         "met_res{}.png".format(file_modifier),
@@ -864,7 +1031,7 @@ def plot_particle_multiplicity(X, yvals, class_names, epoch=None, cp_dir=None, c
         )
 
 
-def plot_particles(yvals, epoch=None, cp_dir=None, comet_experiment=None, title=None):
+def plot_particles(yvals, epoch=None, cp_dir=None, comet_experiment=None, title=None, sample=None, dataset=None):
     msk_cand = yvals["cand_cls_id"] != 0
     cand_pt = awkward.to_numpy(awkward.flatten(yvals["cand_pt"][msk_cand], axis=1))
 
@@ -876,13 +1043,15 @@ def plot_particles(yvals, epoch=None, cp_dir=None, comet_experiment=None, title=
 
     b = np.logspace(-1, 4, 100)
     plt.figure()
+    ax = plt.gca()
     p = med_iqr(cand_pt)
     plt.hist(
         cand_pt,
         bins=b,
         histtype="step",
         lw=2,
-        label="PF $(M={:.2f}, IQR={:.2f})$".format(p[0], p[1]),
+        # label="PF $(M={:.2f}, IQR={:.2f})$".format(p[0], p[1]),
+        label="PF",
     )
     p = med_iqr(pred_pt)
     plt.hist(
@@ -890,7 +1059,8 @@ def plot_particles(yvals, epoch=None, cp_dir=None, comet_experiment=None, title=
         bins=b,
         histtype="step",
         lw=2,
-        label="MLPF $(M={:.2f}, IQR={:.2f})$".format(p[0], p[1]),
+        # label="MLPF $(M={:.2f}, IQR={:.2f})$".format(p[0], p[1]),
+        label="MLPF",
     )
     p = med_iqr(gen_pt)
     plt.hist(
@@ -898,20 +1068,74 @@ def plot_particles(yvals, epoch=None, cp_dir=None, comet_experiment=None, title=
         bins=b,
         histtype="step",
         lw=2,
-        label="Truth $(M={:.2f}, IQR={:.2f})$".format(p[0], p[1]),
+        # label="Truth $(M={:.2f}, IQR={:.2f})$".format(p[0], p[1]),
+        label="Truth",
     )
     plt.xscale("log")
+    plt.yscale("log")
     plt.xlabel("Particle $p_T$ [GeV]")
     plt.ylabel("Number of particles / bin")
     if title:
         plt.title(title)
     plt.legend(loc="best")
+    if dataset:
+        EXPERIMENT_LABELS[dataset](ax)
+    if sample:
+        sample_label(ax, sample)
+    save_img(
+        "particle_pt_log.png",
+        epoch,
+        cp_dir=cp_dir,
+        comet_experiment=comet_experiment,
+    )
+
+    b = np.linspace(0, 200, 100)
+    plt.figure()
+    ax = plt.gca()
+    p = med_iqr(cand_pt)
+    plt.hist(
+        cand_pt,
+        bins=b,
+        histtype="step",
+        lw=2,
+        # label="PF $(M={:.2f}, IQR={:.2f})$".format(p[0], p[1]),
+        label="PF",
+    )
+    p = med_iqr(pred_pt)
+    plt.hist(
+        pred_pt,
+        bins=b,
+        histtype="step",
+        lw=2,
+        # label="MLPF $(M={:.2f}, IQR={:.2f})$".format(p[0], p[1]),
+        label="MLPF",
+    )
+    p = med_iqr(gen_pt)
+    plt.hist(
+        gen_pt,
+        bins=b,
+        histtype="step",
+        lw=2,
+        # label="Truth $(M={:.2f}, IQR={:.2f})$".format(p[0], p[1]),
+        label="Truth",
+    )
+    plt.yscale("log")
+    plt.xlabel("Particle $p_T$ [GeV]")
+    plt.ylabel("Number of particles / bin")
+    if title:
+        plt.title(title)
+    plt.legend(loc="best")
+    if dataset:
+        EXPERIMENT_LABELS[dataset](ax)
+    if sample:
+        sample_label(ax, sample)
     save_img(
         "particle_pt.png",
         epoch,
         cp_dir=cp_dir,
         comet_experiment=comet_experiment,
     )
+
 
     msk_cand = yvals["cand_cls_id"] != 0
     cand_pt = awkward.to_numpy(awkward.flatten(yvals["cand_eta"][msk_cand], axis=1))
@@ -924,13 +1148,14 @@ def plot_particles(yvals, epoch=None, cp_dir=None, comet_experiment=None, title=
 
     b = np.linspace(-8, 8, 100)
     plt.figure()
+    ax = plt.gca()
     p = med_iqr(cand_pt)
     plt.hist(
         cand_pt,
         bins=b,
         histtype="step",
         lw=2,
-        label="PF $(M={:.2f}, IQR={:.2f})$".format(p[0], p[1]),
+        label="PF",
     )
     p = med_iqr(pred_pt)
     plt.hist(
@@ -938,7 +1163,7 @@ def plot_particles(yvals, epoch=None, cp_dir=None, comet_experiment=None, title=
         bins=b,
         histtype="step",
         lw=2,
-        label="MLPF $(M={:.2f}, IQR={:.2f})$".format(p[0], p[1]),
+        label="MLPF",
     )
     p = med_iqr(gen_pt)
     plt.hist(
@@ -946,13 +1171,17 @@ def plot_particles(yvals, epoch=None, cp_dir=None, comet_experiment=None, title=
         bins=b,
         histtype="step",
         lw=2,
-        label="Truth $(M={:.2f}, IQR={:.2f})$".format(p[0], p[1]),
+        label="Truth",
     )
     plt.xlabel(r"Particle $\eta$")
     plt.ylabel("Number of particles / bin")
     if title:
         plt.title(title)
     plt.legend(loc="best")
+    if dataset:
+        EXPERIMENT_LABELS[dataset](ax)
+    if sample:
+        sample_label(ax, sample)
     save_img(
         "particle_eta.png",
         epoch,
@@ -966,14 +1195,14 @@ def plot_particles(yvals, epoch=None, cp_dir=None, comet_experiment=None, title=
 
     cand_pt = awkward.to_numpy(awkward.flatten(yvals["cand_pt"][msk_cand & msk_gen], axis=1))
     gen_pt = awkward.to_numpy(awkward.flatten(yvals["gen_pt"][msk_cand & msk_gen], axis=1))
-    b = np.logspace(-1, 4, 100)
+    b = np.logspace(-1, 2, 100)
     plt.figure()
     plt.hist2d(gen_pt, cand_pt, bins=(b, b), cmap="hot_r")
     plt.xscale("log")
     plt.yscale("log")
     plt.xlabel("True particle $p_T$ [GeV]")
     plt.ylabel("Reconstructed particle $p_T$ [GeV]")
-    plt.plot([10**-1, 10**4], [10**-1, 10**4], color="black", ls="--")
+    plt.plot([10**-1, 10**2], [10**-1, 10**2], color="black", ls="--")
     if title:
         plt.title(title + ", PF")
     save_img(
@@ -985,14 +1214,14 @@ def plot_particles(yvals, epoch=None, cp_dir=None, comet_experiment=None, title=
 
     pred_pt = awkward.to_numpy(awkward.flatten(yvals["pred_pt"][msk_pred & msk_gen], axis=1))
     gen_pt = awkward.to_numpy(awkward.flatten(yvals["gen_pt"][msk_pred & msk_gen], axis=1))
-    b = np.logspace(-1, 4, 100)
+    b = np.logspace(-1, 2, 100)
     plt.figure()
     plt.hist2d(gen_pt, pred_pt, bins=(b, b), cmap="hot_r")
     plt.xscale("log")
     plt.yscale("log")
     plt.xlabel("True particle $p_T$ [GeV]")
     plt.ylabel("Reconstructed particle $p_T$ [GeV]")
-    plt.plot([10**-1, 10**4], [10**-1, 10**4], color="black", ls="--")
+    plt.plot([10**-1, 10**2], [10**-1, 10**2], color="black", ls="--")
     if title:
         plt.title(title + ", MLPF")
     save_img(
@@ -1015,7 +1244,7 @@ def plot_jet_response_binned_separate(yvals, epoch=None, cp_dir=None, comet_expe
     x_vals = []
     pf_vals = []
     mlpf_vals = []
-    b = np.linspace(0, 2, 100)
+    b = np.linspace(0, 5, 100)
 
     for ibin in range(len(genjet_bins) - 1):
         lim_low = genjet_bins[ibin]
@@ -1054,11 +1283,10 @@ def plot_jet_response_binned_separate(yvals, epoch=None, cp_dir=None, comet_expe
         plt.xticks([0, 0.5, 1, 1.5, 2])
         plt.ylabel("Matched jets / bin")
         plt.xlabel(labels["reco_gen_jet_ratio"])
-        plt.axvline(1.0, ymax=0.7, color="black", ls="--")
         plt.legend(loc=1, fontsize=16)
         plt.title(labels["gen_jet_range"].format(lim_low, lim_hi))
         plt.yscale("log")
-
+        plt.tight_layout()
         save_img(
             "jet_response_binned_pt{}.png".format(lim_low),
             epoch,
@@ -1067,7 +1295,7 @@ def plot_jet_response_binned_separate(yvals, epoch=None, cp_dir=None, comet_expe
         )
 
 
-def plot_jet_response_binned(yvals, epoch=None, cp_dir=None, comet_experiment=None, title=None):
+def plot_jet_response_binned(yvals, epoch=None, cp_dir=None, comet_experiment=None, title=None, sample=None, dataset=None):
     pf_genjet_pt = yvals["jet_gen_to_cand_genpt"]
     mlpf_genjet_pt = yvals["jet_gen_to_pred_genpt"]
 
@@ -1079,7 +1307,7 @@ def plot_jet_response_binned(yvals, epoch=None, cp_dir=None, comet_experiment=No
     x_vals = []
     pf_vals = []
     mlpf_vals = []
-    b = np.linspace(0, 2, 100)
+    b = np.linspace(0, 5, 100)
 
     fig, axs = plt.subplots(2, 3, figsize=(3 * 5, 2 * 5))
     axs = axs.flatten()
@@ -1116,8 +1344,6 @@ def plot_jet_response_binned(yvals, epoch=None, cp_dir=None, comet_experiment=No
         plt.sca(axs[ibin])
         plt.hist(pf_subsample, bins=b, histtype="step", lw=2, label="PF")
         plt.hist(mlpf_subsample, bins=b, histtype="step", lw=2, label="MLPF")
-        plt.xlim(0, 2)
-        plt.xticks([0, 0.5, 1, 1.5, 2])
         plt.ylabel("Matched jets / bin")
         plt.xlabel(labels["reco_gen_jet_ratio"])
         plt.axvline(1.0, ymax=0.7, color="black", ls="--")
@@ -1139,21 +1365,46 @@ def plot_jet_response_binned(yvals, epoch=None, cp_dir=None, comet_experiment=No
 
     # Plot median and IQR as a function of gen pt
     plt.figure()
+    ax = plt.gca()
+    plt.plot(x_vals, pf_vals[:, 1], marker="o", label="PF")
+    plt.plot(x_vals, mlpf_vals[:, 1], marker="o", label="MLPF")
+    plt.legend(loc=1, fontsize=16, title=title)
+    plt.ylabel("Response median")
+    plt.xlabel(labels["gen_jet"])
+    plt.tight_layout()
+    plt.axhline(1.0, color="black", ls="--", lw=0.5)
+    if dataset:
+        EXPERIMENT_LABELS[dataset](ax)
+    if sample:
+        sample_label(ax, sample)
+    save_img(
+        "jet_response_med_pt.png",
+        epoch,
+        cp_dir=cp_dir,
+        comet_experiment=comet_experiment,
+    )
+
+    plt.figure()
+    ax = plt.gca()
     plt.plot(x_vals, (pf_vals[:, 2] - pf_vals[:, 0]) / pf_vals[:, 1], marker="o", label="PF")
     plt.plot(x_vals, (mlpf_vals[:, 2] - mlpf_vals[:, 0]) / mlpf_vals[:, 1], marker="o", label="MLPF")
     plt.legend(loc=1, fontsize=16, title=title)
     plt.ylabel("Response IQR / median")
     plt.xlabel(labels["gen_jet"])
     plt.tight_layout()
+    if dataset:
+        EXPERIMENT_LABELS[dataset](ax)
+    if sample:
+        sample_label(ax, sample)
     save_img(
-        "jet_response_med_iqr.png",
+        "jet_response_iqr_over_med_pt.png",
         epoch,
         cp_dir=cp_dir,
         comet_experiment=comet_experiment,
     )
 
 
-def plot_jet_response_binned_eta(yvals, epoch=None, cp_dir=None, comet_experiment=None, title=None):
+def plot_jet_response_binned_eta(yvals, epoch=None, cp_dir=None, comet_experiment=None, title=None, sample=None, dataset=None):
     pf_genjet_eta = yvals["jet_gen_to_cand_geneta"]
     mlpf_genjet_eta = yvals["jet_gen_to_pred_geneta"]
 
@@ -1165,7 +1416,7 @@ def plot_jet_response_binned_eta(yvals, epoch=None, cp_dir=None, comet_experimen
     x_vals = []
     pf_vals = []
     mlpf_vals = []
-    b = np.linspace(0, 2, 100)
+    b = np.linspace(0, 5, 100)
 
     fig, axs = plt.subplots(3, 3, figsize=(3 * 5, 3 * 5))
     axs = axs.flatten()
@@ -1202,11 +1453,8 @@ def plot_jet_response_binned_eta(yvals, epoch=None, cp_dir=None, comet_experimen
         plt.sca(axs[ibin])
         plt.hist(pf_subsample, bins=b, histtype="step", lw=2, label="PF")
         plt.hist(mlpf_subsample, bins=b, histtype="step", lw=2, label="MLPF")
-        plt.xlim(0, 2)
-        plt.xticks([0, 0.5, 1, 1.5, 2])
         plt.ylabel("Matched jets / bin")
         plt.xlabel(labels["reco_gen_jet_ratio"])
-        plt.axvline(1.0, ymax=0.7, color="black", ls="--")
         plt.legend(loc=1, fontsize=16)
         plt.title(labels["gen_jet_range_eta"].format(lim_low, lim_hi))
         plt.yscale("log")
@@ -1223,23 +1471,48 @@ def plot_jet_response_binned_eta(yvals, epoch=None, cp_dir=None, comet_experimen
     pf_vals = np.array(pf_vals)
     mlpf_vals = np.array(mlpf_vals)
 
-    # Plot median and IQR as a function of gen pt
+    # Plot median and IQR as a function of gen eta
     plt.figure()
+    ax = plt.gca()
+    plt.plot(x_vals, pf_vals[:, 1], marker="o", label="PF")
+    plt.plot(x_vals, mlpf_vals[:, 1], marker="o", label="MLPF")
+    plt.ylabel("Response median")
+    plt.xlabel(labels["gen_jet_eta"])
+    plt.tight_layout()
+    plt.legend(loc=1, fontsize=16, title=title)
+    plt.axhline(1.0, color="black", ls="--", lw=0.5)
+    if dataset:
+        EXPERIMENT_LABELS[dataset](ax)
+    if sample:
+        sample_label(ax, sample)
+    save_img(
+        "jet_response_med_eta.png",
+        epoch,
+        cp_dir=cp_dir,
+        comet_experiment=comet_experiment,
+    )
+
+    plt.figure()
+    ax = plt.gca()
     plt.plot(x_vals, (pf_vals[:, 2] - pf_vals[:, 0]) / pf_vals[:, 1], marker="o", label="PF")
     plt.plot(x_vals, (mlpf_vals[:, 2] - mlpf_vals[:, 0]) / mlpf_vals[:, 1], marker="o", label="MLPF")
     plt.ylabel("Response IQR / median")
     plt.xlabel(labels["gen_jet_eta"])
     plt.tight_layout()
     plt.legend(loc=1, fontsize=16, title=title)
+    if dataset:
+        EXPERIMENT_LABELS[dataset](ax)
+    if sample:
+        sample_label(ax, sample)
     save_img(
-        "jet_response_med_iqr_eta.png",
+        "jet_response_iqr_over_med_eta.png",
         epoch,
         cp_dir=cp_dir,
         comet_experiment=comet_experiment,
     )
 
 
-def plot_met_response_binned(yvals, epoch=None, cp_dir=None, comet_experiment=None, title=None):
+def plot_met_response_binned(yvals, epoch=None, cp_dir=None, comet_experiment=None, title=None, sample=None, dataset=None):
     genmet = yvals["gen_met"]
 
     pf_response = yvals["ratio_cand"]
@@ -1250,7 +1523,7 @@ def plot_met_response_binned(yvals, epoch=None, cp_dir=None, comet_experiment=No
     x_vals = []
     pf_vals = []
     mlpf_vals = []
-    b = np.linspace(0, 2, 100)
+    b = np.linspace(0, 5, 100)
 
     fig, axs = plt.subplots(2, 3, figsize=(3 * 5, 2 * 5))
     axs = axs.flatten()
@@ -1285,8 +1558,6 @@ def plot_met_response_binned(yvals, epoch=None, cp_dir=None, comet_experiment=No
         plt.sca(axs[ibin])
         plt.hist(pf_subsample, bins=b, histtype="step", lw=2, label="PF")
         plt.hist(mlpf_subsample, bins=b, histtype="step", lw=2, label="MLPF")
-        plt.xlim(0, 2)
-        plt.xticks([0, 0.5, 1, 1.5, 2])
         plt.ylabel("Events / bin")
         plt.xlabel(labels["reco_gen_met_ratio"])
         plt.axvline(1.0, ymax=0.7, color="black", ls="--")
@@ -1306,7 +1577,27 @@ def plot_met_response_binned(yvals, epoch=None, cp_dir=None, comet_experiment=No
     pf_vals = np.array(pf_vals)
     mlpf_vals = np.array(mlpf_vals)
 
-    # Plot median and IQR as a function of gen pt
+    # Plot median and IQR as a function of gen met
+    plt.figure()
+    plt.plot(x_vals, pf_vals[:, 1], marker="o", label="PF")
+    plt.plot(x_vals, mlpf_vals[:, 1], marker="o", label="MLPF")
+    plt.ylabel("Response median")
+    plt.legend(loc=1, fontsize=16, title=title)
+    plt.xlabel(labels["gen_met"])
+    plt.tight_layout()
+    ax = plt.gca()
+    plt.axhline(1.0, color="black", ls="--", lw=0.5)
+    if dataset:
+        EXPERIMENT_LABELS[dataset](ax)
+    if sample:
+        sample_label(ax, sample)
+    save_img(
+        "met_response_med.png",
+        epoch,
+        cp_dir=cp_dir,
+        comet_experiment=comet_experiment,
+    )
+
     plt.figure()
     plt.plot(x_vals, (pf_vals[:, 2] - pf_vals[:, 0]) / pf_vals[:, 1], marker="o", label="PF")
     plt.plot(x_vals, (mlpf_vals[:, 2] - mlpf_vals[:, 0]) / mlpf_vals[:, 1], marker="o", label="MLPF")
@@ -1314,8 +1605,13 @@ def plot_met_response_binned(yvals, epoch=None, cp_dir=None, comet_experiment=No
     plt.legend(loc=1, fontsize=16, title=title)
     plt.xlabel(labels["gen_met"])
     plt.tight_layout()
+    ax = plt.gca()
+    if dataset:
+        EXPERIMENT_LABELS[dataset](ax)
+    if sample:
+        sample_label(ax, sample)
     save_img(
-        "met_response_med_iqr.png",
+        "met_response_iqr_over_med.png",
         epoch,
         cp_dir=cp_dir,
         comet_experiment=comet_experiment,

--- a/mlpf/pyg/inference.py
+++ b/mlpf/pyg/inference.py
@@ -12,13 +12,11 @@ import vector
 from jet_utils import build_dummy_array, match_two_jet_collections
 from plotting.plot_utils import (
     compute_met_and_ratio,
-    format_dataset_name,
     load_eval_data,
     plot_jets,
     plot_jet_ratio,
     plot_jet_response_binned,
     plot_jet_response_binned_eta,
-    plot_jet_response_binned_separate,
     plot_met,
     plot_met_ratio,
     plot_met_response_binned,
@@ -181,9 +179,8 @@ def make_plots(outpath, sample, dataset, dir_name=""):
 
     yvals, X, _ = load_eval_data(str(pred_path / "*.parquet"), -1)
 
-    # plot_num_elements(X, cp_dir=plots_path, title=title)
-    # plot_sum_energy(yvals, CLASS_NAMES[dataset], cp_dir=plots_path, title=title)
-    # plot_particle_multiplicity(X, yvals, CLASS_NAMES[dataset], cp_dir=plots_path, title=title)
+    plot_num_elements(X, cp_dir=plots_path)
+    plot_sum_energy(yvals, CLASS_NAMES[dataset], cp_dir=plots_path)
 
     plot_jets(
         yvals,
@@ -208,40 +205,14 @@ def make_plots(outpath, sample, dataset, dir_name=""):
         dataset=dataset,
         sample=sample,
     )
-    plot_jet_response_binned(
-        yvals,
-        cp_dir=plots_path,
-        dataset=dataset,
-        sample=sample
-    )
-    plot_jet_response_binned_eta(
-        yvals,
-        cp_dir=plots_path,
-        dataset=dataset,
-        sample=sample
-    )
+    plot_jet_response_binned(yvals, cp_dir=plots_path, dataset=dataset, sample=sample)
+    plot_jet_response_binned_eta(yvals, cp_dir=plots_path, dataset=dataset, sample=sample)
     # plot_jet_response_binned_separate(yvals, cp_dir=plots_path, title=title)
 
     met_data = compute_met_and_ratio(yvals)
-    plot_met(
-        met_data,
-        cp_dir=plots_path,
-        dataset=dataset,
-        sample=sample
-    )
-    plot_met_ratio(
-        met_data,
-        cp_dir=plots_path,
-        dataset=dataset,
-        sample=sample)
-    plot_met_ratio(
-        met_data,
-        cp_dir=plots_path,
-        bins=np.linspace(0, 20, 100),
-        logy=True,
-        dataset=dataset,
-        sample=sample
-    )
+    plot_met(met_data, cp_dir=plots_path, dataset=dataset, sample=sample)
+    plot_met_ratio(met_data, cp_dir=plots_path, dataset=dataset, sample=sample)
+    plot_met_ratio(met_data, cp_dir=plots_path, bins=np.linspace(0, 20, 100), logy=True, dataset=dataset, sample=sample)
     plot_met_ratio(
         met_data,
         cp_dir=plots_path,
@@ -249,7 +220,7 @@ def make_plots(outpath, sample, dataset, dir_name=""):
         logy=False,
         file_modifier="_bins_0_2",
         dataset=dataset,
-        sample=sample
+        sample=sample,
     )
     plot_met_ratio(
         met_data,
@@ -258,17 +229,8 @@ def make_plots(outpath, sample, dataset, dir_name=""):
         logy=False,
         file_modifier="_bins_0_5",
         dataset=dataset,
-        sample=sample
+        sample=sample,
     )
-    plot_met_response_binned(
-        met_data,
-        cp_dir=plots_path,
-        dataset=dataset,
-        sample=sample)
+    plot_met_response_binned(met_data, cp_dir=plots_path, dataset=dataset, sample=sample)
 
-    plot_particles(
-        yvals,
-        cp_dir=plots_path,
-        dataset=dataset,
-        sample=sample
-    )
+    plot_particles(yvals, cp_dir=plots_path, dataset=dataset, sample=sample)

--- a/mlpf/pyg/inference.py
+++ b/mlpf/pyg/inference.py
@@ -48,9 +48,11 @@ def predict_one_batch(conv_type, model, i, batch, rank, jetdef, jet_ptcut, jet_m
         _batch = batch.to(rank)
         ypred = model(_batch.X, _batch.batch)
 
+    ypred = tuple([y.to(torch.float32) for y in ypred])
+
     ygen = unpack_target(batch.ygen.to(torch.float32))
     ycand = unpack_target(batch.ycand.to(torch.float32))
-    ypred = unpack_predictions(ypred.to(torch.float32))
+    ypred = unpack_predictions(ypred)
 
     for k, v in ygen.items():
         ygen[k] = v.detach().cpu()
@@ -170,7 +172,7 @@ def run_predictions(world_size, rank, model, loader, sample, outpath, jetdef, je
 def make_plots(outpath, sample, dataset, dir_name=""):
     """Uses the predictions stored as .parquet files (see above) to make plots."""
 
-    mplhep.set_style(mplhep.styles.CMS)
+    mplhep.style.use(mplhep.styles.CMS)
 
     os.system(f"mkdir -p {outpath}/plots{dir_name}/{sample}")
 
@@ -179,61 +181,94 @@ def make_plots(outpath, sample, dataset, dir_name=""):
 
     yvals, X, _ = load_eval_data(str(pred_path / "*.parquet"), -1)
 
-    title = format_dataset_name(sample)
-    plot_num_elements(X, cp_dir=plots_path, title=title)
-    plot_sum_energy(yvals, CLASS_NAMES[dataset], cp_dir=plots_path, title=title)
+    # plot_num_elements(X, cp_dir=plots_path, title=title)
+    # plot_sum_energy(yvals, CLASS_NAMES[dataset], cp_dir=plots_path, title=title)
     # plot_particle_multiplicity(X, yvals, CLASS_NAMES[dataset], cp_dir=plots_path, title=title)
 
     plot_jets(
         yvals,
         cp_dir=plots_path,
-        title=title,
+        dataset=dataset,
+        sample=sample,
     )
     plot_jet_ratio(
         yvals,
         cp_dir=plots_path,
-        title=title,
         bins=np.linspace(0, 5, 100),
         logy=True,
+        dataset=dataset,
+        sample=sample,
     )
     plot_jet_ratio(
         yvals,
         cp_dir=plots_path,
-        title=title,
         bins=np.linspace(0.5, 1.5, 100),
         logy=False,
         file_modifier="_bins_0p5_1p5",
+        dataset=dataset,
+        sample=sample,
     )
-    plot_jet_response_binned(yvals, cp_dir=plots_path, title=title)
-    plot_jet_response_binned_eta(yvals, cp_dir=plots_path, title=title)
-    plot_jet_response_binned_separate(yvals, cp_dir=plots_path, title=title)
+    plot_jet_response_binned(
+        yvals,
+        cp_dir=plots_path,
+        dataset=dataset,
+        sample=sample
+    )
+    plot_jet_response_binned_eta(
+        yvals,
+        cp_dir=plots_path,
+        dataset=dataset,
+        sample=sample
+    )
+    # plot_jet_response_binned_separate(yvals, cp_dir=plots_path, title=title)
 
     met_data = compute_met_and_ratio(yvals)
-    plot_met(met_data, cp_dir=plots_path, title=title)
-    plot_met_ratio(met_data, cp_dir=plots_path, title=title)
-    plot_met_ratio(
+    plot_met(
         met_data,
         cp_dir=plots_path,
-        title=title,
-        bins=np.linspace(0, 20, 100),
-        logy=True,
+        dataset=dataset,
+        sample=sample
     )
     plot_met_ratio(
         met_data,
         cp_dir=plots_path,
-        title=title,
+        dataset=dataset,
+        sample=sample)
+    plot_met_ratio(
+        met_data,
+        cp_dir=plots_path,
+        bins=np.linspace(0, 20, 100),
+        logy=True,
+        dataset=dataset,
+        sample=sample
+    )
+    plot_met_ratio(
+        met_data,
+        cp_dir=plots_path,
         bins=np.linspace(0, 2, 100),
         logy=False,
         file_modifier="_bins_0_2",
+        dataset=dataset,
+        sample=sample
     )
     plot_met_ratio(
         met_data,
         cp_dir=plots_path,
-        title=title,
         bins=np.linspace(0, 5, 100),
         logy=False,
         file_modifier="_bins_0_5",
+        dataset=dataset,
+        sample=sample
     )
-    plot_met_response_binned(met_data, cp_dir=plots_path, title=title)
+    plot_met_response_binned(
+        met_data,
+        cp_dir=plots_path,
+        dataset=dataset,
+        sample=sample)
 
-    plot_particles(yvals, cp_dir=plots_path, title=format_dataset_name(sample))
+    plot_particles(
+        yvals,
+        cp_dir=plots_path,
+        dataset=dataset,
+        sample=sample
+    )

--- a/mlpf/pyg/inference.py
+++ b/mlpf/pyg/inference.py
@@ -23,7 +23,6 @@ from plotting.plot_utils import (
     plot_met_ratio,
     plot_met_response_binned,
     plot_num_elements,
-    plot_particle_multiplicity,
     plot_particles,
     plot_sum_energy,
 )

--- a/mlpf/pyg/training.py
+++ b/mlpf/pyg/training.py
@@ -659,7 +659,7 @@ def run(rank, world_size, config, args, outdir, logfile):
         optimizer = torch.optim.AdamW(model.parameters(), lr=config["lr"])
 
         checkpoint = torch.load(config["load"], map_location=torch.device(rank))
-        start_epoch = checkpoint["extra_state"]["epoch"]
+        start_epoch = checkpoint["extra_state"]["epoch"] + 1
 
         for k in model.state_dict().keys():
             shp0 = model.state_dict()[k].shape

--- a/mlpf/pyg/training.py
+++ b/mlpf/pyg/training.py
@@ -770,12 +770,12 @@ def run(rank, world_size, config, args, outdir, logfile):
         checkpoint = torch.load(f"{outdir}/best_weights.pth", map_location=torch.device(rank))
         model, optimizer = load_checkpoint(checkpoint, model, optimizer)
 
-    if args.test:
-        if not (config["load"] is None):
-            testdir_name = "_" + Path(config["load"]).stem
-        else:
-            testdir_name = "_bestweights"
+    if not (config["load"] is None):
+        testdir_name = "_" + Path(config["load"]).stem
+    else:
+        testdir_name = "_bestweights"
 
+    if args.test:
         for sample in args.test_datasets:
             batch_size = config["gpu_batch_multiplier"]
             version = config["test_dataset"][sample]["version"]
@@ -797,8 +797,8 @@ def run(rank, world_size, config, args, outdir, logfile):
                 sampler=sampler,
                 num_workers=config["num_workers"],
                 prefetch_factor=config["prefetch_factor"],
-                pin_memory=use_cuda,
-                pin_memory_device="cuda:{}".format(rank) if use_cuda else "",
+                # pin_memory=use_cuda,
+                # pin_memory_device="cuda:{}".format(rank) if use_cuda else "",
             )
 
             if not osp.isdir(f"{outdir}/preds{testdir_name}/{sample}"):

--- a/mlpf/pyg_pipeline.py
+++ b/mlpf/pyg_pipeline.py
@@ -109,6 +109,8 @@ def get_outdir(resume_training, load):
 
 
 def main():
+    # import matplotlib.pyplot as plt
+    # plt.rcParams['text.usetex'] = True
     args = parser.parse_args()
 
     if args.resume_training and not args.ray_train:

--- a/mlpf/pyg_pipeline.py
+++ b/mlpf/pyg_pipeline.py
@@ -104,8 +104,9 @@ def get_outdir(resume_training, load):
             # the checkpoint is likely from a DDP run and we need to step up one dir less
             outdir = str(pload.parent.parent)
     if not (outdir is None):
-        assert(os.path.isfile("{}/model_kwargs.pkl".format(outdir)))
+        assert os.path.isfile("{}/model_kwargs.pkl".format(outdir))
     return outdir
+
 
 def main():
     args = parser.parse_args()

--- a/parameters/pytorch/pyg-cms.yaml
+++ b/parameters/pytorch/pyg-cms.yaml
@@ -120,10 +120,10 @@ train_dataset:
       samples:
         cms_pf_ttbar:
           version: 1.7.1
-#        cms_pf_qcd:
-#          version: 1.7.0
-#        cms_pf_ztt:
-#          version: 1.7.0
+        cms_pf_qcd:
+          version: 1.7.1
+        cms_pf_ztt:
+          version: 1.7.1
 #        cms_pf_qcd_high_pt:
 #          version: 1.7.0
 #        cms_pf_sms_t1tttt:
@@ -160,10 +160,10 @@ valid_dataset:
       samples:
         cms_pf_ttbar:
           version: 1.7.1
-#        cms_pf_qcd:
-#          version: 1.7.0
-#        cms_pf_ztt:
-#          version: 1.7.0
+        cms_pf_qcd:
+          version: 1.7.1
+        cms_pf_ztt:
+          version: 1.7.1
 #        cms_pf_qcd_high_pt:
 #          version: 1.7.0
 #        cms_pf_sms_t1tttt:

--- a/parameters/pytorch/pyg-cms.yaml
+++ b/parameters/pytorch/pyg-cms.yaml
@@ -4,9 +4,9 @@ dataset: cms
 sort_data: yes
 data_dir:
 gpus: 1
-gpu_batch_multiplier: 1
+gpu_batch_multiplier: 20
 load:
-num_epochs: 20
+num_epochs: 100
 patience: 20
 lr: 0.0001
 lr_schedule: cosinedecay  # constant, cosinedecay, onecycle
@@ -14,9 +14,9 @@ conv_type: gnn_lsh
 ntrain:
 ntest:
 nvalid:
-num_workers: 0
-prefetch_factor:
-checkpoint_freq:
+num_workers: 4
+prefetch_factor: 50
+checkpoint_freq: 1
 comet_name: particleflow-pt
 comet_offline: False
 comet_step_freq: 10
@@ -120,38 +120,6 @@ train_dataset:
       samples:
         cms_pf_ttbar:
           version: 1.7.1
-        cms_pf_qcd:
-          version: 1.7.1
-        cms_pf_ztt:
-          version: 1.7.1
-#        cms_pf_qcd_high_pt:
-#          version: 1.7.0
-#        cms_pf_sms_t1tttt:
-#          version: 1.7.0
-#    gun:
-#      batch_size: 20
-#      samples:
-#        cms_pf_single_electron:
-#          version: 1.7.0
-#        cms_pf_single_gamma:
-#          version: 1.7.0
-#        cms_pf_single_pi0:
-#          version: 1.7.0
-#        cms_pf_single_neutron:
-#          version: 1.7.0
-#        cms_pf_single_pi:
-#          version: 1.7.0
-#        cms_pf_single_tau:
-#          version: 1.7.0
-#        cms_pf_single_mu:
-#          version: 1.7.0
-#        cms_pf_single_proton:
-#          version: 1.7.0
-#    multiparticlegun:
-#      batch_size: 4
-#      samples:
-#        cms_pf_multi_particle_gun:
-#          version: 1.7.1
 
 valid_dataset:
   cms:
@@ -160,40 +128,6 @@ valid_dataset:
       samples:
         cms_pf_ttbar:
           version: 1.7.1
-        cms_pf_qcd:
-          version: 1.7.1
-        cms_pf_ztt:
-          version: 1.7.1
-#        cms_pf_qcd_high_pt:
-#          version: 1.7.0
-#        cms_pf_sms_t1tttt:
-#          version: 1.7.0
-#        cms_pf_vbf:
-#          version: 1.7.0
-#    gun:
-#      batch_size: 20
-#      samples:
-#        cms_pf_single_electron:
-#          version: 1.7.0
-#        cms_pf_single_gamma:
-#          version: 1.7.0
-#        cms_pf_single_pi0:
-#          version: 1.7.0
-#        cms_pf_single_neutron:
-#          version: 1.7.0
-#        cms_pf_single_pi:
-#          version: 1.7.0
-#        cms_pf_single_tau:
-#          version: 1.7.0
-#        cms_pf_single_mu:
-#          version: 1.7.0
-#        cms_pf_single_proton:
-#          version: 1.7.0
-#    multiparticlegun:
-#      batch_size: 4
-#      samples:
-#        cms_pf_multi_particle_gun:
-#          version: 1.7.1
 
 test_dataset:
   cms_pf_ttbar:

--- a/parameters/pytorch/pyg-cms.yaml
+++ b/parameters/pytorch/pyg-cms.yaml
@@ -66,7 +66,7 @@ model:
 
   attention:
     conv_type: attention
-    num_convs: 3
+    num_convs: 6
     dropout_ff: 0.0
     dropout_conv_id_mha: 0.0
     dropout_conv_id_ff: 0.0
@@ -74,7 +74,7 @@ model:
     dropout_conv_reg_ff: 0.0
     activation: "relu"
     head_dim: 16
-    num_heads: 16
+    num_heads: 32
     attention_type: flash
 
   mamba:
@@ -119,39 +119,39 @@ train_dataset:
       batch_size: 1
       samples:
         cms_pf_ttbar:
-          version: 1.7.0
-        cms_pf_qcd:
-          version: 1.7.0
-        cms_pf_ztt:
-          version: 1.7.0
-        cms_pf_qcd_high_pt:
-          version: 1.7.0
-        cms_pf_sms_t1tttt:
-          version: 1.7.0
-    gun:
-      batch_size: 20
-      samples:
-        cms_pf_single_electron:
-          version: 1.7.0
-        cms_pf_single_gamma:
-          version: 1.7.0
-        cms_pf_single_pi0:
-          version: 1.7.0
-        cms_pf_single_neutron:
-          version: 1.7.0
-        cms_pf_single_pi:
-          version: 1.7.0
-        cms_pf_single_tau:
-          version: 1.7.0
-        cms_pf_single_mu:
-          version: 1.7.0
-        cms_pf_single_proton:
-          version: 1.7.0
-    multiparticlegun:
-      batch_size: 4
-      samples:
-        cms_pf_multi_particle_gun:
           version: 1.7.1
+#        cms_pf_qcd:
+#          version: 1.7.0
+#        cms_pf_ztt:
+#          version: 1.7.0
+#        cms_pf_qcd_high_pt:
+#          version: 1.7.0
+#        cms_pf_sms_t1tttt:
+#          version: 1.7.0
+#    gun:
+#      batch_size: 20
+#      samples:
+#        cms_pf_single_electron:
+#          version: 1.7.0
+#        cms_pf_single_gamma:
+#          version: 1.7.0
+#        cms_pf_single_pi0:
+#          version: 1.7.0
+#        cms_pf_single_neutron:
+#          version: 1.7.0
+#        cms_pf_single_pi:
+#          version: 1.7.0
+#        cms_pf_single_tau:
+#          version: 1.7.0
+#        cms_pf_single_mu:
+#          version: 1.7.0
+#        cms_pf_single_proton:
+#          version: 1.7.0
+#    multiparticlegun:
+#      batch_size: 4
+#      samples:
+#        cms_pf_multi_particle_gun:
+#          version: 1.7.1
 
 valid_dataset:
   cms:
@@ -159,45 +159,45 @@ valid_dataset:
       batch_size: 1
       samples:
         cms_pf_ttbar:
-          version: 1.7.0
-        cms_pf_qcd:
-          version: 1.7.0
-        cms_pf_ztt:
-          version: 1.7.0
-        cms_pf_qcd_high_pt:
-          version: 1.7.0
-        cms_pf_sms_t1tttt:
-          version: 1.7.0
-        cms_pf_vbf:
-          version: 1.7.0
-    gun:
-      batch_size: 20
-      samples:
-        cms_pf_single_electron:
-          version: 1.7.0
-        cms_pf_single_gamma:
-          version: 1.7.0
-        cms_pf_single_pi0:
-          version: 1.7.0
-        cms_pf_single_neutron:
-          version: 1.7.0
-        cms_pf_single_pi:
-          version: 1.7.0
-        cms_pf_single_tau:
-          version: 1.7.0
-        cms_pf_single_mu:
-          version: 1.7.0
-        cms_pf_single_proton:
-          version: 1.7.0
-    multiparticlegun:
-      batch_size: 4
-      samples:
-        cms_pf_multi_particle_gun:
           version: 1.7.1
+#        cms_pf_qcd:
+#          version: 1.7.0
+#        cms_pf_ztt:
+#          version: 1.7.0
+#        cms_pf_qcd_high_pt:
+#          version: 1.7.0
+#        cms_pf_sms_t1tttt:
+#          version: 1.7.0
+#        cms_pf_vbf:
+#          version: 1.7.0
+#    gun:
+#      batch_size: 20
+#      samples:
+#        cms_pf_single_electron:
+#          version: 1.7.0
+#        cms_pf_single_gamma:
+#          version: 1.7.0
+#        cms_pf_single_pi0:
+#          version: 1.7.0
+#        cms_pf_single_neutron:
+#          version: 1.7.0
+#        cms_pf_single_pi:
+#          version: 1.7.0
+#        cms_pf_single_tau:
+#          version: 1.7.0
+#        cms_pf_single_mu:
+#          version: 1.7.0
+#        cms_pf_single_proton:
+#          version: 1.7.0
+#    multiparticlegun:
+#      batch_size: 4
+#      samples:
+#        cms_pf_multi_particle_gun:
+#          version: 1.7.1
 
 test_dataset:
   cms_pf_ttbar:
-    version: 1.7.0
+    version: 1.7.1
   cms_pf_qcd_high_pt:
     version: 1.7.0
   cms_pf_qcd:

--- a/parameters/pytorch/pyg-cms.yaml
+++ b/parameters/pytorch/pyg-cms.yaml
@@ -198,11 +198,7 @@ valid_dataset:
 test_dataset:
   cms_pf_ttbar:
     version: 1.7.1
-  cms_pf_qcd_high_pt:
-    version: 1.7.0
   cms_pf_qcd:
-    version: 1.7.0
+    version: 1.7.1
   cms_pf_ztt:
-    version: 1.7.0
-  cms_pf_sms_t1tttt:
-    version: 1.7.0
+    version: 1.7.1

--- a/parameters/pytorch/pyg-cms.yaml
+++ b/parameters/pytorch/pyg-cms.yaml
@@ -4,7 +4,7 @@ dataset: cms
 sort_data: yes
 data_dir:
 gpus: 1
-gpu_batch_multiplier: 20
+gpu_batch_multiplier: 1
 load:
 num_epochs: 100
 patience: 20

--- a/scripts/fcc/postprocessing.py
+++ b/scripts/fcc/postprocessing.py
@@ -876,10 +876,10 @@ def process_one_file(fn, ofn):
 
 
 def process_sample(sample):
-    inp = "/local/joosep/clic_edm4hep/"
-    outp = "/local/joosep/mlpf/clic_edm4hep_2023_12_15/"
+    inp = "/local/joosep/clic_edm4hep/2023/"
+    outp = "/local/joosep/mlpf/clic_edm4hep_2024_03_27_allptcls/"
 
-    pool = multiprocessing.Pool(4)
+    pool = multiprocessing.Pool(8)
 
     inpath_samp = inp + sample
     outpath_samp = outp + sample
@@ -891,6 +891,7 @@ def process_sample(sample):
     #    of = inf.replace(inpath_samp, outpath_samp).replace(".root", ".parquet")
     #    process_one_file(inf, of)
     args = []
+    print("processing {} files".format(len(infiles)))
     for inf in infiles:
         of = inf.replace(inpath_samp, outpath_samp).replace(".root", ".parquet")
         args.append((inf, of))
@@ -898,6 +899,7 @@ def process_sample(sample):
 
 
 if __name__ == "__main__":
+    print("running postprocessing.py", sys.argv[1:])
     if len(sys.argv) == 2:
         process_sample(sys.argv[1])
     else:

--- a/scripts/fcc/postprocessing.py
+++ b/scripts/fcc/postprocessing.py
@@ -876,10 +876,10 @@ def process_one_file(fn, ofn):
 
 
 def process_sample(sample):
-    inp = "/local/joosep/clic_edm4hep/2023/"
-    outp = "/local/joosep/mlpf/clic_edm4hep_2024_03_27_allptcls/"
+    inp = "/local/joosep/clic_edm4hep/"
+    outp = "/local/joosep/mlpf/clic_edm4hep_2023_12_15/"
 
-    pool = multiprocessing.Pool(8)
+    pool = multiprocessing.Pool(4)
 
     inpath_samp = inp + sample
     outpath_samp = outp + sample
@@ -891,7 +891,6 @@ def process_sample(sample):
     #    of = inf.replace(inpath_samp, outpath_samp).replace(".root", ".parquet")
     #    process_one_file(inf, of)
     args = []
-    print("processing {} files".format(len(infiles)))
     for inf in infiles:
         of = inf.replace(inpath_samp, outpath_samp).replace(".root", ".parquet")
         args.append((inf, of))
@@ -899,7 +898,6 @@ def process_sample(sample):
 
 
 if __name__ == "__main__":
-    print("running postprocessing.py", sys.argv[1:])
     if len(sys.argv) == 2:
         process_sample(sys.argv[1])
     else:

--- a/scripts/fcc/submit_postprocessing.sh
+++ b/scripts/fcc/submit_postprocessing.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+#SBATCH --partition main
+#SBATCH --cpus-per-task 8
+#SBATCH --mem-per-cpu 2G
+#SBATCH -o logs/slurm-%x-%j-%N.out
+
+singularity exec -B /local /home/software/singularity/tf-2.14.0.simg python3.10 scripts/fcc/postprocessing.py $1

--- a/scripts/generate_tfds.sh
+++ b/scripts/generate_tfds.sh
@@ -3,9 +3,10 @@
 # Tallinn
 export MANUAL_DIR=/local/joosep/mlpf/cms/v3
 export DATA_DIR=/local/joosep/mlpf/cms/v3/tensorflow_datasets
-export IMG=/home/software/singularity/tf-2.14.0.simg
-export PYTHONPATH=`pwd`/mlpf
-export CMD="singularity exec -B /local -B /scratch/persistent --env PYTHONPATH=$PYTHONPATH $IMG tfds build "
+export IMG=/home/software/singularity/pytorch.simg:2024-03-11
+export PYTHONPATH=mlpf
+export KERAS_BACKEND=tensorflow
+export CMD="singularity exec -B /local -B /scratch/persistent $IMG tfds build "
 
 # Desktop
 # IMG=/home/joosep/HEP-KBFI/singularity/tf-2.13.0.simg
@@ -16,8 +17,8 @@ export CMD="singularity exec -B /local -B /scratch/persistent --env PYTHONPATH=$
 # CMS
 export DATA_DIR=/scratch/persistent/joosep/tensorflow_datasets
 #$CMD mlpf/heptfds/cms_pf/ttbar --data_dir $DATA_DIR --manual_dir $MANUAL_DIR/pu55to75 --overwrite &> logs/tfds_ttbar.log &
-#$CMD mlpf/heptfds/cms_pf/qcd --data_dir $DATA_DIR --manual_dir $MANUAL_DIR/pu55to75 --overwrite &> logs/tfds_qcd.log &
-#$CMD mlpf/heptfds/cms_pf/ztt --data_dir $DATA_DIR --manual_dir $MANUAL_DIR/pu55to75 --overwrite &> logs/tfds_ztt.log &
+$CMD mlpf/heptfds/cms_pf/qcd --data_dir $DATA_DIR --manual_dir $MANUAL_DIR/pu55to75 --overwrite &> logs/tfds_qcd.log &
+$CMD mlpf/heptfds/cms_pf/ztt --data_dir $DATA_DIR --manual_dir $MANUAL_DIR/pu55to75 --overwrite &> logs/tfds_ztt.log &
 #$CMD mlpf/heptfds/cms_pf/qcd_high_pt --data_dir $DATA_DIR --manual_dir $MANUAL_DIR/pu55to75 --overwrite &> logs/tfds_qcd_high_pt.log &
 #$CMD mlpf/heptfds/cms_pf/smst1tttt --data_dir $DATA_DIR --manual_dir $MANUAL_DIR/pu55to75 --overwrite &> logs/tfds_smst1tttt.log &
 #$CMD mlpf/heptfds/cms_pf/vbf --data_dir $DATA_DIR --manual_dir $MANUAL_DIR/pu55to75 --overwrite &> logs/tfds_vbf.log &
@@ -29,7 +30,7 @@ export DATA_DIR=/scratch/persistent/joosep/tensorflow_datasets
 #$CMD mlpf/heptfds/cms_pf/singlepi --data_dir $DATA_DIR --manual_dir $MANUAL_DIR/nopu --overwrite &> logs/tfds_singlepi.log &
 #$CMD mlpf/heptfds/cms_pf/singleproton --data_dir $DATA_DIR --manual_dir $MANUAL_DIR/nopu --overwrite &> logs/tfds_singleproton.log &
 #$CMD mlpf/heptfds/cms_pf/singletau --data_dir $DATA_DIR --manual_dir $MANUAL_DIR/nopu --overwrite &> logs/tfds_singletau.log &
-$CMD mlpf/heptfds/cms_pf/multiparticlegun --data_dir $DATA_DIR --manual_dir $MANUAL_DIR/nopu --overwrite &> logs/tfds_multiparticlegun.log &
+#$CMD mlpf/heptfds/cms_pf/multiparticlegun --data_dir $DATA_DIR --manual_dir $MANUAL_DIR/nopu --overwrite &> logs/tfds_multiparticlegun.log &
 wait
 
 # CLIC cluster-based

--- a/scripts/generate_tfds.sh
+++ b/scripts/generate_tfds.sh
@@ -15,23 +15,23 @@ export CMD="singularity exec -B /local -B /scratch/persistent $IMG tfds build "
 # CMD="singularity exec -B /media/joosep/data --env PYTHONPATH=$PYTHONPATH $IMG tfds build "
 
 # CMS
-export DATA_DIR=/scratch/persistent/joosep/tensorflow_datasets
-#$CMD mlpf/heptfds/cms_pf/ttbar --data_dir $DATA_DIR --manual_dir $MANUAL_DIR/pu55to75 --overwrite &> logs/tfds_ttbar.log &
-$CMD mlpf/heptfds/cms_pf/qcd --data_dir $DATA_DIR --manual_dir $MANUAL_DIR/pu55to75 --overwrite &> logs/tfds_qcd.log &
-$CMD mlpf/heptfds/cms_pf/ztt --data_dir $DATA_DIR --manual_dir $MANUAL_DIR/pu55to75 --overwrite &> logs/tfds_ztt.log &
-#$CMD mlpf/heptfds/cms_pf/qcd_high_pt --data_dir $DATA_DIR --manual_dir $MANUAL_DIR/pu55to75 --overwrite &> logs/tfds_qcd_high_pt.log &
-#$CMD mlpf/heptfds/cms_pf/smst1tttt --data_dir $DATA_DIR --manual_dir $MANUAL_DIR/pu55to75 --overwrite &> logs/tfds_smst1tttt.log &
-#$CMD mlpf/heptfds/cms_pf/vbf --data_dir $DATA_DIR --manual_dir $MANUAL_DIR/pu55to75 --overwrite &> logs/tfds_vbf.log &
-#$CMD mlpf/heptfds/cms_pf/singlepi0 --data_dir $DATA_DIR --manual_dir $MANUAL_DIR/nopu --overwrite &> logs/tfds_singlepi0.log &
-#$CMD mlpf/heptfds/cms_pf/singleneutron --data_dir $DATA_DIR --manual_dir $MANUAL_DIR/nopu --overwrite &> logs/tfds_singleneutron.log &
-#$CMD mlpf/heptfds/cms_pf/singleele --data_dir $DATA_DIR --manual_dir $MANUAL_DIR/nopu --overwrite &> logs/tfds_singleele.log &
-#$CMD mlpf/heptfds/cms_pf/singlegamma --data_dir $DATA_DIR --manual_dir $MANUAL_DIR/nopu --overwrite &> logs/tfds_singlegamma.log &
-#$CMD mlpf/heptfds/cms_pf/singlemu --data_dir $DATA_DIR --manual_dir $MANUAL_DIR/nopu --overwrite &> logs/tfds_singlemu.log &
-#$CMD mlpf/heptfds/cms_pf/singlepi --data_dir $DATA_DIR --manual_dir $MANUAL_DIR/nopu --overwrite &> logs/tfds_singlepi.log &
-#$CMD mlpf/heptfds/cms_pf/singleproton --data_dir $DATA_DIR --manual_dir $MANUAL_DIR/nopu --overwrite &> logs/tfds_singleproton.log &
-#$CMD mlpf/heptfds/cms_pf/singletau --data_dir $DATA_DIR --manual_dir $MANUAL_DIR/nopu --overwrite &> logs/tfds_singletau.log &
-#$CMD mlpf/heptfds/cms_pf/multiparticlegun --data_dir $DATA_DIR --manual_dir $MANUAL_DIR/nopu --overwrite &> logs/tfds_multiparticlegun.log &
-wait
+# export DATA_DIR=/scratch/persistent/joosep/tensorflow_datasets
+# $CMD mlpf/heptfds/cms_pf/ttbar --data_dir $DATA_DIR --manual_dir $MANUAL_DIR/pu55to75 --overwrite &> logs/tfds_ttbar.log &
+# $CMD mlpf/heptfds/cms_pf/qcd --data_dir $DATA_DIR --manual_dir $MANUAL_DIR/pu55to75 --overwrite &> logs/tfds_qcd.log &
+# $CMD mlpf/heptfds/cms_pf/ztt --data_dir $DATA_DIR --manual_dir $MANUAL_DIR/pu55to75 --overwrite &> logs/tfds_ztt.log &
+# $CMD mlpf/heptfds/cms_pf/qcd_high_pt --data_dir $DATA_DIR --manual_dir $MANUAL_DIR/pu55to75 --overwrite &> logs/tfds_qcd_high_pt.log &
+# $CMD mlpf/heptfds/cms_pf/smst1tttt --data_dir $DATA_DIR --manual_dir $MANUAL_DIR/pu55to75 --overwrite &> logs/tfds_smst1tttt.log &
+# $CMD mlpf/heptfds/cms_pf/vbf --data_dir $DATA_DIR --manual_dir $MANUAL_DIR/pu55to75 --overwrite &> logs/tfds_vbf.log &
+# $CMD mlpf/heptfds/cms_pf/singlepi0 --data_dir $DATA_DIR --manual_dir $MANUAL_DIR/nopu --overwrite &> logs/tfds_singlepi0.log &
+# $CMD mlpf/heptfds/cms_pf/singleneutron --data_dir $DATA_DIR --manual_dir $MANUAL_DIR/nopu --overwrite &> logs/tfds_singleneutron.log &
+# $CMD mlpf/heptfds/cms_pf/singleele --data_dir $DATA_DIR --manual_dir $MANUAL_DIR/nopu --overwrite &> logs/tfds_singleele.log &
+# $CMD mlpf/heptfds/cms_pf/singlegamma --data_dir $DATA_DIR --manual_dir $MANUAL_DIR/nopu --overwrite &> logs/tfds_singlegamma.log &
+# $CMD mlpf/heptfds/cms_pf/singlemu --data_dir $DATA_DIR --manual_dir $MANUAL_DIR/nopu --overwrite &> logs/tfds_singlemu.log &
+# $CMD mlpf/heptfds/cms_pf/singlepi --data_dir $DATA_DIR --manual_dir $MANUAL_DIR/nopu --overwrite &> logs/tfds_singlepi.log &
+# $CMD mlpf/heptfds/cms_pf/singleproton --data_dir $DATA_DIR --manual_dir $MANUAL_DIR/nopu --overwrite &> logs/tfds_singleproton.log &
+# $CMD mlpf/heptfds/cms_pf/singletau --data_dir $DATA_DIR --manual_dir $MANUAL_DIR/nopu --overwrite &> logs/tfds_singletau.log &
+# $CMD mlpf/heptfds/cms_pf/multiparticlegun --data_dir $DATA_DIR --manual_dir $MANUAL_DIR/nopu --overwrite &> logs/tfds_multiparticlegun.log &
+# wait
 
 # CLIC cluster-based
 # export MANUAL_DIR=/local/joosep/mlpf/clic_edm4hep/

--- a/scripts/tallinn/a100/pytorch.sh
+++ b/scripts/tallinn/a100/pytorch.sh
@@ -12,10 +12,4 @@ singularity exec -B /scratch/persistent --nv \
     --env KERAS_BACKEND=torch \
     $IMG python3.10 mlpf/pyg_pipeline.py --dataset cms --gpus 1 \
     --data-dir /scratch/persistent/joosep/tensorflow_datasets --config parameters/pytorch/pyg-cms.yaml \
-    --train --conv-type attention --num-epochs 100 --gpu-batch-multiplier 20 --num-workers 4 --prefetch-factor 50 --checkpoint-freq 1 --comet --load experiments/pyg-cms_20240331_100326_706273/checkpoints/checkpoint-02-18.142171.pth
-
-# singularity exec -B /scratch/persistent --nv \
-#     --env PYTHONPATH=hep_tfds \
-#     $IMG python3.10 mlpf/pyg_pipeline.py --dataset cms --gpus 1 \
-#     --data-dir /scratch/persistent/joosep/tensorflow_datasets --config parameters/pytorch/pyg-cms.yaml \
-#     --test --make-plots --conv-type attention --gpu-batch-multiplier 40 --num-workers 2 --prefetch-factor 20 --load experiments/pyg-cms_20240218_204141_378871/checkpoints/checkpoint-05-48.080534.pth --ntest 1000
+    --train --conv-type attention --num-epochs 100 --gpu-batch-multiplier 20 --num-workers 4 --prefetch-factor 50 --checkpoint-freq 1 --comet

--- a/scripts/tallinn/a100/pytorch.sh
+++ b/scripts/tallinn/a100/pytorch.sh
@@ -12,7 +12,7 @@ singularity exec -B /scratch/persistent --nv \
     --env KERAS_BACKEND=torch \
     $IMG python3.10 mlpf/pyg_pipeline.py --dataset cms --gpus 1 \
     --data-dir /scratch/persistent/joosep/tensorflow_datasets --config parameters/pytorch/pyg-cms.yaml \
-    --train --conv-type attention --num-epochs 100 --gpu-batch-multiplier 20 --num-workers 4 --prefetch-factor 50 --checkpoint-freq 1 --comet
+    --train --conv-type attention --num-epochs 100 --gpu-batch-multiplier 20 --num-workers 4 --prefetch-factor 50 --checkpoint-freq 1 --comet --load experiments/pyg-cms_20240331_100326_706273/checkpoints/checkpoint-02-18.142171.pth
 
 # singularity exec -B /scratch/persistent --nv \
 #     --env PYTHONPATH=hep_tfds \

--- a/scripts/tallinn/a100/pytorch.sh
+++ b/scripts/tallinn/a100/pytorch.sh
@@ -12,7 +12,7 @@ singularity exec -B /scratch/persistent --nv \
     --env KERAS_BACKEND=torch \
     $IMG python3.10 mlpf/pyg_pipeline.py --dataset cms --gpus 1 \
     --data-dir /scratch/persistent/joosep/tensorflow_datasets --config parameters/pytorch/pyg-cms.yaml \
-    --train --conv-type attention --num-epochs 20 --gpu-batch-multiplier 40 --num-workers 4 --prefetch-factor 50 --checkpoint-freq 1 --comet
+    --train --conv-type attention --num-epochs 100 --gpu-batch-multiplier 20 --num-workers 4 --prefetch-factor 50 --checkpoint-freq 1 --comet
 
 # singularity exec -B /scratch/persistent --nv \
 #     --env PYTHONPATH=hep_tfds \


### PR DESCRIPTION
- generate more CMS training data, deploy datasets v.1.7.1 to EOS
- speed up CMS tfds production (slowness from `np.append_fields`)
- speed up inference code (slowness from `awkward.from_iter`)
- improve plotting style
- fix start epoch overlapping with the previous epoch when loading a model and continuing training
- fix model loading, do not create empty experiment dirs when not needed (e.g. evaluation)