### PR TITLE
fix CMS instructions

### DIFF
--- a/mlpf/data_cms/README.md
+++ b/mlpf/data_cms/README.md
@@ -52,42 +52,6 @@ md5sum RecoParticleFlow/PFProducer/data/mlpf/mlpf_21M_attn2x6x512_bs40_relu_tt_q
 ```
 
 ## Running MLPF in CMSSW
-MLPF is integrated in CMSSW reconstruction and can be run either using simple but slow matrix workflows, or using the faster but more elaborate PF validation.
-
-### Matrix workflows
-
-Matrix workflows allow to run MLPF directly out of the box, rerunning the full reconstruction chain.
-This is easy to run, but time consuming.
-```
-#check the workflows with the .13 suffix (that have MLPF enabled)
-> runTheMatrix.py --what upgrade -n | grep "\.13"
-
-#Run this workflow TTbar_14TeV + 2021PU_mlpf
-> runTheMatrix.py --what upgrade -l 11834.13
-
-#Takes around 30 minutes
-11834.13_TTbar_14TeV+2021PU_mlpf+TTbar_14TeV_TuneCP5_GenSim+DigiPU+RecoNanoPU+HARVESTNanoPU Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Thu May 16 15:24:47 2024-date Thu May 16 15:06:24 2024; exit: 0 0 0 0
-1 1 1 1 tests passed, 0 0 0 0 failed
-```
-
-Check the outputs
-```
-> ls 11834.13_TTbar_14TeV+2021PU_mlpf+TTbar_14TeV_TuneCP5_GenSim+DigiPU+RecoNanoPU+HARVESTNanoPU/*.root
-11834.13_TTbar_14TeV+2021PU_mlpf+TTbar_14TeV_TuneCP5_GenSim+DigiPU+RecoNanoPU+HARVESTNanoPU/DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO.root
-11834.13_TTbar_14TeV+2021PU_mlpf+TTbar_14TeV_TuneCP5_GenSim+DigiPU+RecoNanoPU+HARVESTNanoPU/histProbFunction.root
-11834.13_TTbar_14TeV+2021PU_mlpf+TTbar_14TeV_TuneCP5_GenSim+DigiPU+RecoNanoPU+HARVESTNanoPU/step1.root
-11834.13_TTbar_14TeV+2021PU_mlpf+TTbar_14TeV_TuneCP5_GenSim+DigiPU+RecoNanoPU+HARVESTNanoPU/step2.root
-11834.13_TTbar_14TeV+2021PU_mlpf+TTbar_14TeV_TuneCP5_GenSim+DigiPU+RecoNanoPU+HARVESTNanoPU/step3_inDQM.root
-11834.13_TTbar_14TeV+2021PU_mlpf+TTbar_14TeV_TuneCP5_GenSim+DigiPU+RecoNanoPU+HARVESTNanoPU/step3_inMINIAODSIM.root
-11834.13_TTbar_14TeV+2021PU_mlpf+TTbar_14TeV_TuneCP5_GenSim+DigiPU+RecoNanoPU+HARVESTNanoPU/step3_inNANOEDMAODSIM.root
-11834.13_TTbar_14TeV+2021PU_mlpf+TTbar_14TeV_TuneCP5_GenSim+DigiPU+RecoNanoPU+HARVESTNanoPU/step3_inRECOSIM.root
-11834.13_TTbar_14TeV+2021PU_mlpf+TTbar_14TeV_TuneCP5_GenSim+DigiPU+RecoNanoPU+HARVESTNanoPU/step3.root
-```
-
-The particle flow candidates can be found in `step3.root`:
-```
-vector<reco::PFCandidate>             "particleFlow"              ""                "RECO"
-```
 
 ### PF validation
 To test MLPF on higher statistics, it's not practical to redo full reconstruction before the particle flow step.

--- a/scripts/cmssw/validation_job.sh
+++ b/scripts/cmssw/validation_job.sh
@@ -15,9 +15,8 @@ WORKDIR=$CMSSW_BASE/work_${SAMPLE}_${JOBTYPE}_${NJOB}
 # cd /scratch/persistent/joosep/CMSSW_14_1_0_pre3
 # eval `scram runtime -sh`
 # cd $PREVDIR
-
-export OUTDIR=/local/joosep/mlpf/results/cms/${CMSSW_VERSION}/
-export WORKDIR=/scratch/local/$USER/${SLURM_JOB_ID}
+# OUTDIR=/local/joosep/mlpf/results/cms/${CMSSW_VERSION}/
+# WORKDIR=/scratch/local/$USER/${SLURM_JOB_ID}
 
 #abort on error, print all commands
 set -e


### PR DESCRIPTION
Based on the discussion with Andy, the RelVals for the matrix workflows are no longer available (strange).
However, we don't really need the matrix workflows for testing in the first place, it's better and more direct to test directly on GEN-SIM-DIGI-RECO (a la PFValidation).

```
----- Begin Fatal Exception 08-Jul-2024 23:07:06 CEST-----------------------
An exception of category 'FallbackFileOpenError' occurred while
   [0] Constructing the EventProcessor
   [1] Constructing module: class=MixingModule label='mix'
   [2] Calling RootInputFileSequence::initTheFile()
   [3] Calling StorageFactory::open()
   [4] Calling XrdFile::open()
Exception Message:
Failed to open the file 'root://xrootd-cms.infn.it//store/relval/CMSSW_13_1_0_pre1/RelValMinBias_14TeV/GEN-SIM/130X_mcRun3_2022_realistic_withNewBSFromEOY2022Data_v2_RV186-v1/00000/3a417d3c-eada-4641-99e8-31c73d1cdbec.root'
   Additional Info:
      [a] Calling RootInputFileSequence::initTheFile(): fail to open the file with name root://eoscms.cern.ch//eos/cms/store/relval/CMSSW_13_1_0_pre1/RelValMinBias_14TeV/GEN-SIM/130X_mcRun3_2022_realistic_withNewBSFromEOY2022Data_v2_RV186-v1/00000/3a417d3c-eada-4641-99e8-31c73d1cdbec.root
      [b] Input file root://xrootd-cms.infn.it//store/relval/CMSSW_13_1_0_pre1/RelValMinBias_14TeV/GEN-SIM/130X_mcRun3_2022_realistic_withNewBSFromEOY2022Data_v2_RV186-v1/00000/3a417d3c-eada-4641-99e8-31c73d1cdbec.root could not be opened.
      [c] XrdCl::File::Open(name='root://xrootd-cms.infn.it//store/relval/CMSSW_13_1_0_pre1/RelValMinBias_14TeV/GEN-SIM/130X_mcRun3_2022_realistic_withNewBSFromEOY2022Data_v2_RV186-v1/00000/3a417d3c-eada-4641-99e8-31c73d1cdbec.root', flags=0x10, permissions=0660) => error '[ERROR] Server responded with an error: [3011] No servers are available to read the file.
' (errno=3011, code=400). No additional data servers were found.
      [d] Last URL tried: root://cms-xrd-global.cern.ch:1094//store/relval/CMSSW_13_1_0_pre1/RelValMinBias_14TeV/GEN-SIM/130X_mcRun3_2022_realistic_withNewBSFromEOY2022Data_v2_RV186-v1/00000/3a417d3c-eada-4641-99e8-31c73d1cdbec.root?tried=+1213llrxrd-redir.in2p3.fr,&xrdcl.requuid=57004fda-81c5-4b19-a712-48ff4ac9956d
      [e] Problematic data server: cms-xrd-global.cern.ch:1094
      [f] Disabled source: cms-xrd-global.cern.ch:1094
----- End Fatal Exception -------------------------------------------------
```

Also fix env vars in the validation script.