### PR TITLE
Unify key4hep

### DIFF
--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -182,9 +182,7 @@ class EventData:
         self.cluster_features = cluster_features  # feature matrix of the calo clusters
         self.track_features = track_features  # feature matrix of the tracks
         self.genparticle_to_hit = genparticle_to_hit  # sparse COO matrix of genparticles to hits (idx_gp, idx_hit, weight)
-        self.genparticle_to_track = (
-            genparticle_to_track  # sparse COO matrix of genparticles to tracks (idx_gp, idx_track, weight)
-        )
+        self.genparticle_to_track = genparticle_to_track  # sparse COO matrix of genparticles to tracks (idx_gp, idx_track, weight)
         self.hit_to_cluster = hit_to_cluster  # sparse COO matrix of hits to clusters (idx_hit, idx_cluster, weight)
         self.gp_merges = gp_merges  # sparse COO matrix of any merged genparticles
 
@@ -250,10 +248,7 @@ def get_calohit_matrix_and_genadj(dataset, hit_data, calohit_links, iev, collect
             hit_idx_global += 1
     hit_idx_local_to_global = {v: k for k, v in hit_idx_global_to_local.items()}
     hit_feature_matrix = awkward.Record(
-        {
-            k: awkward.concatenate([hit_feature_matrix[i][k] for i in range(len(hit_feature_matrix))])
-            for k in hit_feature_matrix[0].fields
-        }
+        {k: awkward.concatenate([hit_feature_matrix[i][k] for i in range(len(hit_feature_matrix))]) for k in hit_feature_matrix[0].fields}
     )
 
     # add all edges from genparticle to calohit
@@ -353,9 +348,7 @@ def gen_to_features(dataset, prop_data, iev):
     gen_arr = {k.replace(mc_coll + ".", ""): gen_arr[k] for k in gen_arr.fields}
 
     MCParticles_p4 = vector.awk(
-        awkward.zip(
-            {"mass": gen_arr["mass"], "x": gen_arr["momentum.x"], "y": gen_arr["momentum.y"], "z": gen_arr["momentum.z"]}
-        )
+        awkward.zip({"mass": gen_arr["mass"], "x": gen_arr["momentum.x"], "y": gen_arr["momentum.y"], "z": gen_arr["momentum.z"]})
     )
     gen_arr["pt"] = MCParticles_p4.pt
     gen_arr["eta"] = MCParticles_p4.eta
@@ -542,9 +535,7 @@ def track_to_features(dataset, prop_data, iev):
             ret[k] = awkward.to_numpy(prop_data["SiTracks_1"]["SiTracks_1." + k][iev][trackstate_idx])
         elif dataset == "fcc":
             # ret[k] = awkward.to_numpy(prop_data["_SiTracks_trackStates"]["_SiTracks_trackStates." + k][iev][trackstate_idx])
-            ret[k] = awkward.to_numpy(
-                prop_data["_SiTracks_Refitted_trackStates"]["_SiTracks_Refitted_trackStates." + k][iev][trackstate_idx]
-            )
+            ret[k] = awkward.to_numpy(prop_data["_SiTracks_Refitted_trackStates"]["_SiTracks_Refitted_trackStates." + k][iev][trackstate_idx])
 
         else:
             raise Exception("--dataset provided is not supported. Only 'fcc' or 'clic' are supported atm.")
@@ -633,9 +624,7 @@ def add_daughters_to_status1(gen_features, genparticle_to_hit, genparticle_to_tr
 
 def get_genparticles_and_adjacencies(dataset, prop_data, hit_data, calohit_links, sitrack_links, iev, collectionIDs):
     gen_features = gen_to_features(dataset, prop_data, iev)
-    hit_features, genparticle_to_hit, hit_idx_local_to_global = get_calohit_matrix_and_genadj(
-        dataset, hit_data, calohit_links, iev, collectionIDs
-    )
+    hit_features, genparticle_to_hit, hit_idx_local_to_global = get_calohit_matrix_and_genadj(dataset, hit_data, calohit_links, iev, collectionIDs)
     hit_to_cluster = hit_cluster_adj(dataset, prop_data, hit_idx_local_to_global, iev)
     cluster_features = cluster_to_features(prop_data, hit_features, hit_to_cluster, iev)
     track_features = track_to_features(dataset, prop_data, iev)
@@ -645,9 +634,7 @@ def get_genparticles_and_adjacencies(dataset, prop_data, hit_data, calohit_links
     mask_status1 = gen_features["generatorStatus"] == 1
 
     if gen_features["index"] is not None:  # if there are even daughters
-        genparticle_to_hit, genparticle_to_trk = add_daughters_to_status1(
-            gen_features, genparticle_to_hit, genparticle_to_trk
-        )
+        genparticle_to_hit, genparticle_to_trk = add_daughters_to_status1(gen_features, genparticle_to_hit, genparticle_to_trk)
 
     n_gp = awkward.count(gen_features["PDG"])
     n_track = awkward.count(track_features["type"])
@@ -655,11 +642,7 @@ def get_genparticles_and_adjacencies(dataset, prop_data, hit_data, calohit_links
     n_cluster = awkward.count(cluster_features["type"])
 
     if len(genparticle_to_trk[0]) > 0:
-        gp_to_track = (
-            coo_matrix((genparticle_to_trk[2], (genparticle_to_trk[0], genparticle_to_trk[1])), shape=(n_gp, n_track))
-            .max(axis=1)
-            .todense()
-        )
+        gp_to_track = coo_matrix((genparticle_to_trk[2], (genparticle_to_trk[0], genparticle_to_trk[1])), shape=(n_gp, n_track)).max(axis=1).todense()
     else:
         gp_to_track = np.zeros((n_gp, 1))
 
@@ -689,9 +672,7 @@ def get_genparticles_and_adjacencies(dataset, prop_data, hit_data, calohit_links
 
     if len(np.array(mask_visible)) == 1:
         # event has only one particle (then index will be empty because no daughters)
-        gen_features = awkward.Record(
-            {feat: (gen_features[feat][mask_visible] if feat != "index" else None) for feat in gen_features.keys()}
-        )
+        gen_features = awkward.Record({feat: (gen_features[feat][mask_visible] if feat != "index" else None) for feat in gen_features.keys()})
     else:
         gen_features = awkward.Record({feat: gen_features[feat][mask_visible] for feat in gen_features.keys()})
 
@@ -724,12 +705,8 @@ def assign_genparticles_to_obj_and_merge(gpdata):
         ).todense()
     )
 
-    gp_to_calohit = coo_matrix(
-        (gpdata.genparticle_to_hit[2], (gpdata.genparticle_to_hit[0], gpdata.genparticle_to_hit[1])), shape=(n_gp, n_hit)
-    )
-    calohit_to_cluster = coo_matrix(
-        (gpdata.hit_to_cluster[2], (gpdata.hit_to_cluster[0], gpdata.hit_to_cluster[1])), shape=(n_hit, n_cluster)
-    )
+    gp_to_calohit = coo_matrix((gpdata.genparticle_to_hit[2], (gpdata.genparticle_to_hit[0], gpdata.genparticle_to_hit[1])), shape=(n_gp, n_hit))
+    calohit_to_cluster = coo_matrix((gpdata.hit_to_cluster[2], (gpdata.hit_to_cluster[0], gpdata.hit_to_cluster[1])), shape=(n_hit, n_cluster))
 
     gp_to_cluster = np.array((gp_to_calohit * calohit_to_cluster).todense())
 
@@ -909,9 +886,7 @@ def get_reco_properties(dataset, prop_data, iev):
         raise Exception("--dataset provided is not supported. Only 'fcc' or 'clic' are supported atm.")
 
     reco_p4 = vector.awk(
-        awkward.zip(
-            {"mass": reco_arr["mass"], "x": reco_arr["momentum.x"], "y": reco_arr["momentum.y"], "z": reco_arr["momentum.z"]}
-        )
+        awkward.zip({"mass": reco_arr["mass"], "x": reco_arr["momentum.x"], "y": reco_arr["momentum.y"], "z": reco_arr["momentum.z"]})
     )
     reco_arr["pt"] = reco_p4.pt
     reco_arr["eta"] = reco_p4.eta
@@ -1230,29 +1205,19 @@ def process_one_file(fn, ofn, dataset):
         assert np.all(used_rps == 1)
 
         gps_track = get_particle_feature_matrix(track_to_gp_all, gpdata_cleaned.gen_features, particle_feature_order)
-        gps_track[:, 0] = np.array(
-            [map_neutral_to_charged(map_pdgid_to_candid(p, c)) for p, c in zip(gps_track[:, 0], gps_track[:, 1])]
-        )
+        gps_track[:, 0] = np.array([map_neutral_to_charged(map_pdgid_to_candid(p, c)) for p, c in zip(gps_track[:, 0], gps_track[:, 1])])
         gps_cluster = get_particle_feature_matrix(cluster_to_gp_all, gpdata_cleaned.gen_features, particle_feature_order)
-        gps_cluster[:, 0] = np.array(
-            [map_charged_to_neutral(map_pdgid_to_candid(p, c)) for p, c in zip(gps_cluster[:, 0], gps_cluster[:, 1])]
-        )
+        gps_cluster[:, 0] = np.array([map_charged_to_neutral(map_pdgid_to_candid(p, c)) for p, c in zip(gps_cluster[:, 0], gps_cluster[:, 1])])
         gps_cluster[:, 1] = 0
 
         rps_track = get_particle_feature_matrix(track_to_rp_all, reco_features, particle_feature_order)
-        rps_track[:, 0] = np.array(
-            [map_neutral_to_charged(map_pdgid_to_candid(p, c)) for p, c in zip(rps_track[:, 0], rps_track[:, 1])]
-        )
+        rps_track[:, 0] = np.array([map_neutral_to_charged(map_pdgid_to_candid(p, c)) for p, c in zip(rps_track[:, 0], rps_track[:, 1])])
         rps_cluster = get_particle_feature_matrix(cluster_to_rp_all, reco_features, particle_feature_order)
-        rps_cluster[:, 0] = np.array(
-            [map_charged_to_neutral(map_pdgid_to_candid(p, c)) for p, c in zip(rps_cluster[:, 0], rps_cluster[:, 1])]
-        )
+        rps_cluster[:, 0] = np.array([map_charged_to_neutral(map_pdgid_to_candid(p, c)) for p, c in zip(rps_cluster[:, 0], rps_cluster[:, 1])])
         rps_cluster[:, 1] = 0
 
         # all initial gen/reco particle energy must be reconstructable
-        assert (
-            abs(np.sum(gps_track[:, 6]) + np.sum(gps_cluster[:, 6]) - np.sum(gpdata_cleaned.gen_features["energy"])) < 1e-2
-        )
+        assert abs(np.sum(gps_track[:, 6]) + np.sum(gps_cluster[:, 6]) - np.sum(gpdata_cleaned.gen_features["energy"])) < 1e-2
 
         assert abs(np.sum(rps_track[:, 6]) + np.sum(rps_cluster[:, 6]) - np.sum(reco_features["energy"])) < 1e-2
 
@@ -1299,9 +1264,7 @@ def process_one_file(fn, ofn, dataset):
         sorted_jet_idx = awkward.argsort(target_jets.pt, axis=-1, ascending=False).to_list()
         target_jets_indices = target_jets_indices.to_list()
         for jet_idx in sorted_jet_idx:
-            jet_constituents = [
-                index_mapping[idx] for idx in target_jets_indices[jet_idx]
-            ]  # map back to constituent index *before* masking
+            jet_constituents = [index_mapping[idx] for idx in target_jets_indices[jet_idx]]  # map back to constituent index *before* masking
             ytarget_constituents[jet_constituents] = jet_idx
         ytarget_track_constituents = ytarget_constituents[: len(ytarget_track)]
         ytarget_cluster_constituents = ytarget_constituents[len(ytarget_track) :]

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -633,7 +633,7 @@ def get_genparticles_and_adjacencies(dataset, prop_data, hit_data, calohit_links
 
     print("mask_visible", mask_visible)
     for feat in gen_features.keys():
-        print("feat", gen_features[feat].size)
+        print("feat", gen_features[feat].to_numpy().shape)
         break
     # if len(mask_visible) == 1:
 

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -491,18 +491,50 @@ def cluster_to_features(prop_data, hit_features, hit_to_cluster, iev):
 
 
 def track_to_features(dataset, prop_data, iev):
-    # track_arr = prop_data[track_coll][iev]
-    # feats_from_track = ["type", "chi2", "ndf", "dEdx", "dEdxError", "radiusOfInnermostHit"]
-    # ret = {feat: track_arr[track_coll + "." + feat] for feat in feats_from_track}
+    if dataset == "clic":
+        track_arr = prop_data[track_coll][iev]
+        feats_from_track = ["type", "chi2", "ndf", "dEdx", "dEdxError", "radiusOfInnermostHit"]
+        ret = {feat: track_arr[track_coll + "." + feat] for feat in feats_from_track}
 
-    track_arr = prop_data[track_coll][iev]
-    feats_from_track = ["type", "chi2", "ndf"]
-    ret = {feat: track_arr[track_coll + "." + feat] for feat in feats_from_track}
+    elif dataset == "fcc":
+        track_arr = prop_data[track_coll][iev]
+        feats_from_track = ["type", "chi2", "ndf"]
+        ret = {feat: track_arr[track_coll + "." + feat] for feat in feats_from_track}
 
-    track_arr = prop_data["SiTracks_Refitted_dQdx"][iev]
-    ret["dEdx"] = track_arr["SiTracks_Refitted_dQdx.dQdx.value"]
-    ret["dEdxError"] = track_arr["SiTracks_Refitted_dQdx.dQdx.error"]
-    ret["radiusOfInnermostHit"] = track_arr["SiTracks_Refitted_dQdx.dQdx.error"]  # TODO: fix
+        track_arr = prop_data["SiTracks_Refitted_dQdx"][iev]
+        ret["dEdx"] = track_arr["SiTracks_Refitted_dQdx.dQdx.value"]
+        ret["dEdxError"] = track_arr["SiTracks_Refitted_dQdx.dQdx.error"]
+        ret["radiusOfInnermostHit"] = track_arr["SiTracks_Refitted_dQdx.dQdx.error"]  # TODO: fix
+
+        # num_tracks = len(track_arr[track_coll + "." + "type"])
+        # innermost_radius = []
+        # for itrack in range(num_tracks):
+
+        #     # select the track states corresponding to itrack
+        #     # pick the state AtFirstHit
+        #     # https://github.com/key4hep/EDM4hep/blob/fe5a54046a91a7e648d0b588960db7841aebc670/edm4hep.yaml#L220
+
+        #     ibegin = prop_data["SiTracks_Refitted/SiTracks_Refitted.trackStates_begin"].array()[iev][itrack]
+        #     iend = prop_data["SiTracks_Refitted/SiTracks_Refitted.trackStates_end"].array()[iev][itrack]
+
+        #     refX = prop_data["_SiTracks_Refitted_trackStates/_SiTracks_Refitted_trackStates.referencePoint.x"].array()[iev][
+        #         ibegin:iend
+        #     ]
+        #     refY = prop_data["_SiTracks_Refitted_trackStates/_SiTracks_Refitted_trackStates.referencePoint.y"].array()[iev][
+        #         ibegin:iend
+        #     ]
+        #     location = prop_data["_SiTracks_Refitted_trackStates/_SiTracks_Refitted_trackStates.location"].array()[iev][
+        #         ibegin:iend
+        #     ]
+
+        #     istate = np.argmax(location == 2)  # 2 refers to AtFirstHit
+
+        #     innermost_radius.append(math.sqrt(refX[istate] ** 2 + refY[istate] ** 2))
+
+        # ret["radiusOfInnermostHit"] = np.array(innermost_radius)
+
+    else:
+        raise Exception("--dataset provided is not supported. Only 'fcc' or 'clic' are supported atm.")
 
     n_tr = len(ret["type"])
 

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -633,6 +633,8 @@ def get_genparticles_and_adjacencies(dataset, prop_data, hit_data, calohit_links
 
     if mask_visible.sum() == 0:
         return None
+    else:
+        print("mask_visible.sum()", mask_visible.sum())
 
     gen_features = awkward.Record({feat: gen_features[feat][mask_visible] for feat in gen_features.keys()})
 

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -596,7 +596,7 @@ def get_genparticles_and_adjacencies(dataset, prop_data, hit_data, calohit_links
     # collect hits of st=1 daughters to the st=1 particles
     mask_status1 = gen_features["generatorStatus"] == 1
 
-    if gen_features["index"] is not None:
+    if gen_features["index"] is not None:  # if there are even daughters
         genparticle_to_hit, genparticle_to_trk = add_daughters_to_status1(
             gen_features, genparticle_to_hit, genparticle_to_trk
         )

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -645,7 +645,9 @@ def get_genparticles_and_adjacencies(dataset, prop_data, hit_data, calohit_links
 
         # return None
 
-    gen_features = awkward.Record({feat: gen_features[feat][mask_visible] for feat in gen_features.keys()})
+    gen_features = awkward.Record(
+        {feat: gen_features[feat][mask_visible] for feat in gen_features.keys() if len(gen_features[feat]) != 0}
+    )
 
     genparticle_to_hit = filter_adj(genparticle_to_hit, genpart_idx_all_to_filtered)
     genparticle_to_trk = filter_adj(genparticle_to_trk, genpart_idx_all_to_filtered)

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -495,7 +495,7 @@ def track_to_features(dataset, prop_data, iev):
 
     track_arr = prop_data[track_coll][iev]
     feats_from_track = ["type", "chi2", "ndf"]
-    ret = {feat: track_arr[track_coll + "/" + track_coll + "." + feat] for feat in feats_from_track}
+    ret = {feat: track_arr[track_coll + "." + feat] for feat in feats_from_track}
 
     track_arr = prop_data["SiTracks_Refitted_dQdx"][iev]
     ret["dEdx"] = track_arr["SiTracks_Refitted_dQdx/SiTracks_Refitted_dQdx.dQdx.value"]

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -513,7 +513,7 @@ def track_to_features(dataset, prop_data, iev):
             # select the track states corresponding to itrack
             # pick the state AtFirstHit
             # https://github.com/key4hep/EDM4hep/blob/fe5a54046a91a7e648d0b588960db7841aebc670/edm4hep.yaml#L220
-            print(prop_data["SiTracks_Refitted"].keys())
+            print(prop_data["SiTracks_Refitted"].fields())
             ibegin = prop_data["SiTracks_Refitted.trackStates_begin"].array()[iev][itrack]
             iend = prop_data["SiTracks_Refitted.trackStates_end"].array()[iev][itrack]
 

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -631,7 +631,9 @@ def get_genparticles_and_adjacencies(dataset, prop_data, hit_data, calohit_links
     idx_all_masked = np.where(mask_visible)[0]
     genpart_idx_all_to_filtered = {idx_all: idx_filtered for idx_filtered, idx_all in enumerate(idx_all_masked)}
 
-    print("mask_visible", mask_visible)
+    if mask_visible.sum() == 0:
+        return None
+
     gen_features = awkward.Record({feat: gen_features[feat][mask_visible] for feat in gen_features.keys()})
 
     genparticle_to_hit = filter_adj(genparticle_to_hit, genpart_idx_all_to_filtered)
@@ -1124,6 +1126,8 @@ def process_one_file(fn, ofn, dataset):
             iev,
             collectionIDs,
         )
+        if gpdata is None:
+            continue
 
         # find the reconstructable genparticles and associate them to the best track/cluster
         gpdata_cleaned, gp_to_obj = assign_genparticles_to_obj_and_merge(gpdata)

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -514,16 +514,16 @@ def track_to_features(dataset, prop_data, iev):
             # pick the state AtFirstHit
             # https://github.com/key4hep/EDM4hep/blob/fe5a54046a91a7e648d0b588960db7841aebc670/edm4hep.yaml#L220
 
-            ibegin = prop_data["SiTracks_Refitted/SiTracks_Refitted.trackStates_begin"].array()[iev][itrack]
-            iend = prop_data["SiTracks_Refitted/SiTracks_Refitted.trackStates_end"].array()[iev][itrack]
+            ibegin = prop_data["SiTracks_Refitted.trackStates_begin"].array()[iev][itrack]
+            iend = prop_data["SiTracks_Refitted.trackStates_end"].array()[iev][itrack]
 
-            refX = prop_data["_SiTracks_Refitted_trackStates/_SiTracks_Refitted_trackStates.referencePoint.x"].array()[iev][
+            refX = prop_data["_SiTracks_Refitted_trackStates.referencePoint.x"].array()[iev][
                 ibegin:iend
             ]
-            refY = prop_data["_SiTracks_Refitted_trackStates/_SiTracks_Refitted_trackStates.referencePoint.y"].array()[iev][
+            refY = prop_data["_SiTracks_Refitted_trackStates.referencePoint.y"].array()[iev][
                 ibegin:iend
             ]
-            location = prop_data["_SiTracks_Refitted_trackStates/_SiTracks_Refitted_trackStates.location"].array()[iev][
+            location = prop_data["_SiTracks_Refitted_trackStates.location"].array()[iev][
                 ibegin:iend
             ]
 

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -631,13 +631,15 @@ def get_genparticles_and_adjacencies(dataset, prop_data, hit_data, calohit_links
     idx_all_masked = np.where(mask_visible)[0]
     genpart_idx_all_to_filtered = {idx_all: idx_filtered for idx_filtered, idx_all in enumerate(idx_all_masked)}
 
+    if np.array(mask_visible).sum() == 0:
+        return None
+
     if len(np.array(mask_visible)) == 1:
-        print("only one particle exists in the event, will skip the event.")
+        print("mask_visible", mask_visible)
 
         for feat in gen_features.keys():
             print("feat", feat)
             print("gen_features[feat]", gen_features[feat])
-            print("mask_visible", mask_visible)
             print("try", gen_features[feat][mask_visible])
             # break
 

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -513,13 +513,14 @@ def track_to_features(dataset, prop_data, iev):
             # select the track states corresponding to itrack
             # pick the state AtFirstHit
             # https://github.com/key4hep/EDM4hep/blob/fe5a54046a91a7e648d0b588960db7841aebc670/edm4hep.yaml#L220
-            print(prop_data["SiTracks_Refitted"][0].fields())
-            ibegin = prop_data["SiTracks_Refitted.trackStates_begin"].array()[iev][itrack]
-            iend = prop_data["SiTracks_Refitted.trackStates_end"].array()[iev][itrack]
+            track_arr = prop_data[track_coll][iev]
+            ibegin = track_arr[track_coll + "." + "trackStates_begin"].array()[iev][itrack]
+            iend = track_arr[track_coll + "." + "trackStates_end"].array()[iev][itrack]
 
-            refX = prop_data["_SiTracks_Refitted_trackStates.referencePoint.x"].array()[iev][ibegin:iend]
-            refY = prop_data["_SiTracks_Refitted_trackStates.referencePoint.y"].array()[iev][ibegin:iend]
-            location = prop_data["_SiTracks_Refitted_trackStates.location"].array()[iev][ibegin:iend]
+            track_arr = prop_data["_SiTracks_Refitted_trackStates"][iev]
+            refX = track_arr["_SiTracks_Refitted_trackStates" + "." + "referencePoint.x"].array()[iev][ibegin:iend]
+            refY = track_arr["_SiTracks_Refitted_trackStates" + "." + "referencePoint.y"].array()[iev][ibegin:iend]
+            location = track_arr["_SiTracks_Refitted_trackStates" + "." + "location"].array()[iev][ibegin:iend]
 
             istate = np.argmax(location == 2)  # 2 refers to AtFirstHit
 

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -513,19 +513,13 @@ def track_to_features(dataset, prop_data, iev):
             # select the track states corresponding to itrack
             # pick the state AtFirstHit
             # https://github.com/key4hep/EDM4hep/blob/fe5a54046a91a7e648d0b588960db7841aebc670/edm4hep.yaml#L220
-
+            print(prop_data["SiTracks_Refitted"].keys())
             ibegin = prop_data["SiTracks_Refitted.trackStates_begin"].array()[iev][itrack]
             iend = prop_data["SiTracks_Refitted.trackStates_end"].array()[iev][itrack]
 
-            refX = prop_data["_SiTracks_Refitted_trackStates.referencePoint.x"].array()[iev][
-                ibegin:iend
-            ]
-            refY = prop_data["_SiTracks_Refitted_trackStates.referencePoint.y"].array()[iev][
-                ibegin:iend
-            ]
-            location = prop_data["_SiTracks_Refitted_trackStates.location"].array()[iev][
-                ibegin:iend
-            ]
+            refX = prop_data["_SiTracks_Refitted_trackStates.referencePoint.x"].array()[iev][ibegin:iend]
+            refY = prop_data["_SiTracks_Refitted_trackStates.referencePoint.y"].array()[iev][ibegin:iend]
+            location = prop_data["_SiTracks_Refitted_trackStates.location"].array()[iev][ibegin:iend]
 
             istate = np.argmax(location == 2)  # 2 refers to AtFirstHit
 

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -264,10 +264,15 @@ def get_calohit_matrix_and_genadj(dataset, hit_data, calohit_links, iev, collect
         calohit_to_gen_calo_idx = calohit_links["CalohitMCTruthLink#0.index"][iev]
         calohit_to_gen_gen_idx = calohit_links["CalohitMCTruthLink#1.index"][iev]
     elif dataset == "fcc":
-        calohit_to_gen_calo_colid = calohit_links["_CalohitMCTruthLink_rec/_CalohitMCTruthLink_rec.collectionID"][iev]
-        calohit_to_gen_gen_colid = calohit_links["_CalohitMCTruthLink_sim/_CalohitMCTruthLink_sim.collectionID"][iev]
-        calohit_to_gen_calo_idx = calohit_links["_CalohitMCTruthLink_rec/_CalohitMCTruthLink_rec.index"][iev]
-        calohit_to_gen_gen_idx = calohit_links["_CalohitMCTruthLink_sim/_CalohitMCTruthLink_sim.index"][iev]
+        # calohit_to_gen_calo_colid = calohit_links["_CalohitMCTruthLink_rec/_CalohitMCTruthLink_rec.collectionID"][iev]
+        # calohit_to_gen_gen_colid = calohit_links["_CalohitMCTruthLink_sim/_CalohitMCTruthLink_sim.collectionID"][iev]
+        # calohit_to_gen_calo_idx = calohit_links["_CalohitMCTruthLink_rec/_CalohitMCTruthLink_rec.index"][iev]
+        # calohit_to_gen_gen_idx = calohit_links["_CalohitMCTruthLink_sim/_CalohitMCTruthLink_sim.index"][iev]
+
+        calohit_to_gen_calo_colid = calohit_links["_CalohitMCTruthLink_to/_CalohitMCTruthLink_to.collectionID"][iev]
+        calohit_to_gen_gen_colid = calohit_links["_CalohitMCTruthLink_from/_CalohitMCTruthLink_from.collectionID"][iev]
+        calohit_to_gen_calo_idx = calohit_links["_CalohitMCTruthLink_to/_CalohitMCTruthLink_to.index"][iev]
+        calohit_to_gen_gen_idx = calohit_links["_CalohitMCTruthLink_from/_CalohitMCTruthLink_from.index"][iev]        
     else:
         raise Exception("--dataset provided is not supported. Only 'fcc' or 'clic' are supported atm.")
 

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -402,8 +402,10 @@ def genparticle_track_adj(dataset, sitrack_links, iev):
         trk_to_gen_trkidx = sitrack_links["SiTracksMCTruthLink#0.index"][iev]
         trk_to_gen_genidx = sitrack_links["SiTracksMCTruthLink#1.index"][iev]
     elif dataset == "fcc":
-        trk_to_gen_trkidx = sitrack_links["_SiTracksMCTruthLink_rec/_SiTracksMCTruthLink_rec.index"][iev]
-        trk_to_gen_genidx = sitrack_links["_SiTracksMCTruthLink_sim/_SiTracksMCTruthLink_sim.index"][iev]
+        # trk_to_gen_trkidx = sitrack_links["_SiTracksMCTruthLink_rec/_SiTracksMCTruthLink_rec.index"][iev]
+        # trk_to_gen_genidx = sitrack_links["_SiTracksMCTruthLink_sim/_SiTracksMCTruthLink_sim.index"][iev]
+        trk_to_gen_trkidx = sitrack_links["_SiTracksMCTruthLink_from/_SiTracksMCTruthLink_from.index"][iev]
+        trk_to_gen_genidx = sitrack_links["_SiTracksMCTruthLink_to/_SiTracksMCTruthLink_to.index"][iev]
     else:
         raise Exception("--dataset provided is not supported. Only 'fcc' or 'clic' are supported atm.")
 

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -182,9 +182,7 @@ class EventData:
         self.cluster_features = cluster_features  # feature matrix of the calo clusters
         self.track_features = track_features  # feature matrix of the tracks
         self.genparticle_to_hit = genparticle_to_hit  # sparse COO matrix of genparticles to hits (idx_gp, idx_hit, weight)
-        self.genparticle_to_track = (
-            genparticle_to_track  # sparse COO matrix of genparticles to tracks (idx_gp, idx_track, weight)
-        )
+        self.genparticle_to_track = genparticle_to_track  # sparse COO matrix of genparticles to tracks (idx_gp, idx_track, weight)
         self.hit_to_cluster = hit_to_cluster  # sparse COO matrix of hits to clusters (idx_hit, idx_cluster, weight)
         self.gp_merges = gp_merges  # sparse COO matrix of any merged genparticles
 
@@ -250,10 +248,7 @@ def get_calohit_matrix_and_genadj(dataset, hit_data, calohit_links, iev, collect
             hit_idx_global += 1
     hit_idx_local_to_global = {v: k for k, v in hit_idx_global_to_local.items()}
     hit_feature_matrix = awkward.Record(
-        {
-            k: awkward.concatenate([hit_feature_matrix[i][k] for i in range(len(hit_feature_matrix))])
-            for k in hit_feature_matrix[0].fields
-        }
+        {k: awkward.concatenate([hit_feature_matrix[i][k] for i in range(len(hit_feature_matrix))]) for k in hit_feature_matrix[0].fields}
     )
 
     # add all edges from genparticle to calohit
@@ -348,9 +343,7 @@ def gen_to_features(dataset, prop_data, iev):
     gen_arr = {k.replace(mc_coll + ".", ""): gen_arr[k] for k in gen_arr.fields}
 
     MCParticles_p4 = vector.awk(
-        awkward.zip(
-            {"mass": gen_arr["mass"], "x": gen_arr["momentum.x"], "y": gen_arr["momentum.y"], "z": gen_arr["momentum.z"]}
-        )
+        awkward.zip({"mass": gen_arr["mass"], "x": gen_arr["momentum.x"], "y": gen_arr["momentum.y"], "z": gen_arr["momentum.z"]})
     )
     gen_arr["pt"] = MCParticles_p4.pt
     gen_arr["eta"] = MCParticles_p4.eta
@@ -535,9 +528,7 @@ def track_to_features(dataset, prop_data, iev):
         if dataset == "clic":
             ret[k] = awkward.to_numpy(prop_data["SiTracks_1"]["SiTracks_1." + k][iev][trackstate_idx])
         elif dataset == "fcc":
-            ret[k] = awkward.to_numpy(
-                prop_data["_SiTracks_Refitted_trackStates"]["_SiTracks_Refitted_trackStates." + k][iev][trackstate_idx]
-            )
+            ret[k] = awkward.to_numpy(prop_data["_SiTracks_Refitted_trackStates"]["_SiTracks_Refitted_trackStates." + k][iev][trackstate_idx])
 
         else:
             raise Exception("--dataset provided is not supported. Only 'fcc' or 'clic' are supported atm.")
@@ -626,9 +617,7 @@ def add_daughters_to_status1(gen_features, genparticle_to_hit, genparticle_to_tr
 
 def get_genparticles_and_adjacencies(dataset, prop_data, hit_data, calohit_links, sitrack_links, iev, collectionIDs):
     gen_features = gen_to_features(dataset, prop_data, iev)
-    hit_features, genparticle_to_hit, hit_idx_local_to_global = get_calohit_matrix_and_genadj(
-        dataset, hit_data, calohit_links, iev, collectionIDs
-    )
+    hit_features, genparticle_to_hit, hit_idx_local_to_global = get_calohit_matrix_and_genadj(dataset, hit_data, calohit_links, iev, collectionIDs)
     hit_to_cluster = hit_cluster_adj(dataset, prop_data, hit_idx_local_to_global, iev)
     cluster_features = cluster_to_features(prop_data, hit_features, hit_to_cluster, iev)
     track_features = track_to_features(dataset, prop_data, iev)
@@ -638,9 +627,7 @@ def get_genparticles_and_adjacencies(dataset, prop_data, hit_data, calohit_links
     mask_status1 = gen_features["generatorStatus"] == 1
 
     if gen_features["index"] is not None:  # if there are even daughters
-        genparticle_to_hit, genparticle_to_trk = add_daughters_to_status1(
-            gen_features, genparticle_to_hit, genparticle_to_trk
-        )
+        genparticle_to_hit, genparticle_to_trk = add_daughters_to_status1(gen_features, genparticle_to_hit, genparticle_to_trk)
 
     n_gp = awkward.count(gen_features["PDG"])
     n_track = awkward.count(track_features["type"])
@@ -648,11 +635,7 @@ def get_genparticles_and_adjacencies(dataset, prop_data, hit_data, calohit_links
     n_cluster = awkward.count(cluster_features["type"])
 
     if len(genparticle_to_trk[0]) > 0:
-        gp_to_track = (
-            coo_matrix((genparticle_to_trk[2], (genparticle_to_trk[0], genparticle_to_trk[1])), shape=(n_gp, n_track))
-            .max(axis=1)
-            .todense()
-        )
+        gp_to_track = coo_matrix((genparticle_to_trk[2], (genparticle_to_trk[0], genparticle_to_trk[1])), shape=(n_gp, n_track)).max(axis=1).todense()
     else:
         gp_to_track = np.zeros((n_gp, 1))
 
@@ -682,9 +665,7 @@ def get_genparticles_and_adjacencies(dataset, prop_data, hit_data, calohit_links
 
     if len(np.array(mask_visible)) == 1:
         # event has only one particle (then index will be empty because no daughters)
-        gen_features = awkward.Record(
-            {feat: (gen_features[feat][mask_visible] if feat != "index" else None) for feat in gen_features.keys()}
-        )
+        gen_features = awkward.Record({feat: (gen_features[feat][mask_visible] if feat != "index" else None) for feat in gen_features.keys()})
     else:
         gen_features = awkward.Record({feat: gen_features[feat][mask_visible] for feat in gen_features.keys()})
 
@@ -717,12 +698,8 @@ def assign_genparticles_to_obj_and_merge(gpdata):
         ).todense()
     )
 
-    gp_to_calohit = coo_matrix(
-        (gpdata.genparticle_to_hit[2], (gpdata.genparticle_to_hit[0], gpdata.genparticle_to_hit[1])), shape=(n_gp, n_hit)
-    )
-    calohit_to_cluster = coo_matrix(
-        (gpdata.hit_to_cluster[2], (gpdata.hit_to_cluster[0], gpdata.hit_to_cluster[1])), shape=(n_hit, n_cluster)
-    )
+    gp_to_calohit = coo_matrix((gpdata.genparticle_to_hit[2], (gpdata.genparticle_to_hit[0], gpdata.genparticle_to_hit[1])), shape=(n_gp, n_hit))
+    calohit_to_cluster = coo_matrix((gpdata.hit_to_cluster[2], (gpdata.hit_to_cluster[0], gpdata.hit_to_cluster[1])), shape=(n_hit, n_cluster))
 
     gp_to_cluster = np.array((gp_to_calohit * calohit_to_cluster).todense())
 
@@ -902,9 +879,7 @@ def get_reco_properties(dataset, prop_data, iev):
         raise Exception("--dataset provided is not supported. Only 'fcc' or 'clic' are supported atm.")
 
     reco_p4 = vector.awk(
-        awkward.zip(
-            {"mass": reco_arr["mass"], "x": reco_arr["momentum.x"], "y": reco_arr["momentum.y"], "z": reco_arr["momentum.z"]}
-        )
+        awkward.zip({"mass": reco_arr["mass"], "x": reco_arr["momentum.x"], "y": reco_arr["momentum.y"], "z": reco_arr["momentum.z"]})
     )
     reco_arr["pt"] = reco_p4.pt
     reco_arr["eta"] = reco_p4.eta
@@ -1214,29 +1189,19 @@ def process_one_file(fn, ofn, dataset):
         assert np.all(used_rps == 1)
 
         gps_track = get_particle_feature_matrix(track_to_gp_all, gpdata_cleaned.gen_features, particle_feature_order)
-        gps_track[:, 0] = np.array(
-            [map_neutral_to_charged(map_pdgid_to_candid(p, c)) for p, c in zip(gps_track[:, 0], gps_track[:, 1])]
-        )
+        gps_track[:, 0] = np.array([map_neutral_to_charged(map_pdgid_to_candid(p, c)) for p, c in zip(gps_track[:, 0], gps_track[:, 1])])
         gps_cluster = get_particle_feature_matrix(cluster_to_gp_all, gpdata_cleaned.gen_features, particle_feature_order)
-        gps_cluster[:, 0] = np.array(
-            [map_charged_to_neutral(map_pdgid_to_candid(p, c)) for p, c in zip(gps_cluster[:, 0], gps_cluster[:, 1])]
-        )
+        gps_cluster[:, 0] = np.array([map_charged_to_neutral(map_pdgid_to_candid(p, c)) for p, c in zip(gps_cluster[:, 0], gps_cluster[:, 1])])
         gps_cluster[:, 1] = 0
 
         rps_track = get_particle_feature_matrix(track_to_rp_all, reco_features, particle_feature_order)
-        rps_track[:, 0] = np.array(
-            [map_neutral_to_charged(map_pdgid_to_candid(p, c)) for p, c in zip(rps_track[:, 0], rps_track[:, 1])]
-        )
+        rps_track[:, 0] = np.array([map_neutral_to_charged(map_pdgid_to_candid(p, c)) for p, c in zip(rps_track[:, 0], rps_track[:, 1])])
         rps_cluster = get_particle_feature_matrix(cluster_to_rp_all, reco_features, particle_feature_order)
-        rps_cluster[:, 0] = np.array(
-            [map_charged_to_neutral(map_pdgid_to_candid(p, c)) for p, c in zip(rps_cluster[:, 0], rps_cluster[:, 1])]
-        )
+        rps_cluster[:, 0] = np.array([map_charged_to_neutral(map_pdgid_to_candid(p, c)) for p, c in zip(rps_cluster[:, 0], rps_cluster[:, 1])])
         rps_cluster[:, 1] = 0
 
         # all initial gen/reco particle energy must be reconstructable
-        assert (
-            abs(np.sum(gps_track[:, 6]) + np.sum(gps_cluster[:, 6]) - np.sum(gpdata_cleaned.gen_features["energy"])) < 1e-2
-        )
+        assert abs(np.sum(gps_track[:, 6]) + np.sum(gps_cluster[:, 6]) - np.sum(gpdata_cleaned.gen_features["energy"])) < 1e-2
 
         assert abs(np.sum(rps_track[:, 6]) + np.sum(rps_cluster[:, 6]) - np.sum(reco_features["energy"])) < 1e-2
 
@@ -1283,9 +1248,7 @@ def process_one_file(fn, ofn, dataset):
         sorted_jet_idx = awkward.argsort(target_jets.pt, axis=-1, ascending=False).to_list()
         target_jets_indices = target_jets_indices.to_list()
         for jet_idx in sorted_jet_idx:
-            jet_constituents = [
-                index_mapping[idx] for idx in target_jets_indices[jet_idx]
-            ]  # map back to constituent index *before* masking
+            jet_constituents = [index_mapping[idx] for idx in target_jets_indices[jet_idx]]  # map back to constituent index *before* masking
             ytarget_constituents[jet_constituents] = jet_idx
         ytarget_track_constituents = ytarget_constituents[: len(ytarget_track)]
         ytarget_cluster_constituents = ytarget_constituents[len(ytarget_track) :]

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -506,7 +506,7 @@ def track_to_features(dataset, prop_data, iev):
         ret["dEdxError"] = track_arr["SiTracks_Refitted_dQdx.dQdx.error"]
         # ret["radiusOfInnermostHit"] = track_arr["SiTracks_Refitted_dQdx.dQdx.error"]  # TODO: fix
 
-        num_tracks = len(track_arr[track_coll + "." + "type"])
+        num_tracks = len(track_arr["SiTracks_Refitted_dQdx.dQdx.value"])
         innermost_radius = []
         for itrack in range(num_tracks):
 

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -493,11 +493,11 @@ def track_to_features(dataset, prop_data, iev):
     # feats_from_track = ["type", "chi2", "ndf", "dEdx", "dEdxError", "radiusOfInnermostHit"]
     # ret = {feat: track_arr[track_coll + "." + feat] for feat in feats_from_track}
 
-    track_arr = {**prop_data[track_coll][iev], **prop_data["SiTracks_Refitted_dQdx"][iev]}
-
+    track_arr = prop_data[track_coll][iev]
     feats_from_track = ["type", "chi2", "ndf"]
     ret = {feat: track_arr[track_coll + "/" + track_coll + "." + feat] for feat in feats_from_track}
 
+    track_arr = prop_data["SiTracks_Refitted_dQdx"][iev]
     ret["dEdx"] = track_arr["SiTracks_Refitted_dQdx/SiTracks_Refitted_dQdx.dQdx.value"]
     ret["dEdxError"] = track_arr["SiTracks_Refitted_dQdx/SiTracks_Refitted_dQdx.dQdx.error"]
     ret["radiusOfInnermostHit"] = track_arr["SiTracks_Refitted/SiTracks_Refitted.Nholes"]  # TODO: fix

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -182,7 +182,9 @@ class EventData:
         self.cluster_features = cluster_features  # feature matrix of the calo clusters
         self.track_features = track_features  # feature matrix of the tracks
         self.genparticle_to_hit = genparticle_to_hit  # sparse COO matrix of genparticles to hits (idx_gp, idx_hit, weight)
-        self.genparticle_to_track = genparticle_to_track  # sparse COO matrix of genparticles to tracks (idx_gp, idx_track, weight)
+        self.genparticle_to_track = (
+            genparticle_to_track  # sparse COO matrix of genparticles to tracks (idx_gp, idx_track, weight)
+        )
         self.hit_to_cluster = hit_to_cluster  # sparse COO matrix of hits to clusters (idx_hit, idx_cluster, weight)
         self.gp_merges = gp_merges  # sparse COO matrix of any merged genparticles
 
@@ -248,7 +250,10 @@ def get_calohit_matrix_and_genadj(dataset, hit_data, calohit_links, iev, collect
             hit_idx_global += 1
     hit_idx_local_to_global = {v: k for k, v in hit_idx_global_to_local.items()}
     hit_feature_matrix = awkward.Record(
-        {k: awkward.concatenate([hit_feature_matrix[i][k] for i in range(len(hit_feature_matrix))]) for k in hit_feature_matrix[0].fields}
+        {
+            k: awkward.concatenate([hit_feature_matrix[i][k] for i in range(len(hit_feature_matrix))])
+            for k in hit_feature_matrix[0].fields
+        }
     )
 
     # add all edges from genparticle to calohit
@@ -343,7 +348,9 @@ def gen_to_features(dataset, prop_data, iev):
     gen_arr = {k.replace(mc_coll + ".", ""): gen_arr[k] for k in gen_arr.fields}
 
     MCParticles_p4 = vector.awk(
-        awkward.zip({"mass": gen_arr["mass"], "x": gen_arr["momentum.x"], "y": gen_arr["momentum.y"], "z": gen_arr["momentum.z"]})
+        awkward.zip(
+            {"mass": gen_arr["mass"], "x": gen_arr["momentum.x"], "y": gen_arr["momentum.y"], "z": gen_arr["momentum.z"]}
+        )
     )
     gen_arr["pt"] = MCParticles_p4.pt
     gen_arr["eta"] = MCParticles_p4.eta
@@ -578,7 +585,9 @@ def add_daughters_to_status1(gen_features, genparticle_to_hit, genparticle_to_tr
 
 def get_genparticles_and_adjacencies(dataset, prop_data, hit_data, calohit_links, sitrack_links, iev, collectionIDs):
     gen_features = gen_to_features(dataset, prop_data, iev)
-    hit_features, genparticle_to_hit, hit_idx_local_to_global = get_calohit_matrix_and_genadj(dataset, hit_data, calohit_links, iev, collectionIDs)
+    hit_features, genparticle_to_hit, hit_idx_local_to_global = get_calohit_matrix_and_genadj(
+        dataset, hit_data, calohit_links, iev, collectionIDs
+    )
     hit_to_cluster = hit_cluster_adj(dataset, prop_data, hit_idx_local_to_global, iev)
     cluster_features = cluster_to_features(prop_data, hit_features, hit_to_cluster, iev)
     track_features = track_to_features(dataset, prop_data, iev)
@@ -588,7 +597,9 @@ def get_genparticles_and_adjacencies(dataset, prop_data, hit_data, calohit_links
     mask_status1 = gen_features["generatorStatus"] == 1
 
     if gen_features["index"] is not None:  # if there are even daughters
-        genparticle_to_hit, genparticle_to_trk = add_daughters_to_status1(gen_features, genparticle_to_hit, genparticle_to_trk)
+        genparticle_to_hit, genparticle_to_trk = add_daughters_to_status1(
+            gen_features, genparticle_to_hit, genparticle_to_trk
+        )
 
     n_gp = awkward.count(gen_features["PDG"])
     n_track = awkward.count(track_features["type"])
@@ -596,7 +607,11 @@ def get_genparticles_and_adjacencies(dataset, prop_data, hit_data, calohit_links
     n_cluster = awkward.count(cluster_features["type"])
 
     if len(genparticle_to_trk[0]) > 0:
-        gp_to_track = coo_matrix((genparticle_to_trk[2], (genparticle_to_trk[0], genparticle_to_trk[1])), shape=(n_gp, n_track)).max(axis=1).todense()
+        gp_to_track = (
+            coo_matrix((genparticle_to_trk[2], (genparticle_to_trk[0], genparticle_to_trk[1])), shape=(n_gp, n_track))
+            .max(axis=1)
+            .todense()
+        )
     else:
         gp_to_track = np.zeros((n_gp, 1))
 
@@ -626,7 +641,9 @@ def get_genparticles_and_adjacencies(dataset, prop_data, hit_data, calohit_links
 
     if len(np.array(mask_visible)) == 1:
         # event has only one particle (then index will be empty because no daughters)
-        gen_features = awkward.Record({feat: (gen_features[feat][mask_visible] if feat != "index" else None) for feat in gen_features.keys()})
+        gen_features = awkward.Record(
+            {feat: (gen_features[feat][mask_visible] if feat != "index" else None) for feat in gen_features.keys()}
+        )
     else:
         gen_features = awkward.Record({feat: gen_features[feat][mask_visible] for feat in gen_features.keys()})
 
@@ -659,8 +676,12 @@ def assign_genparticles_to_obj_and_merge(gpdata):
         ).todense()
     )
 
-    gp_to_calohit = coo_matrix((gpdata.genparticle_to_hit[2], (gpdata.genparticle_to_hit[0], gpdata.genparticle_to_hit[1])), shape=(n_gp, n_hit))
-    calohit_to_cluster = coo_matrix((gpdata.hit_to_cluster[2], (gpdata.hit_to_cluster[0], gpdata.hit_to_cluster[1])), shape=(n_hit, n_cluster))
+    gp_to_calohit = coo_matrix(
+        (gpdata.genparticle_to_hit[2], (gpdata.genparticle_to_hit[0], gpdata.genparticle_to_hit[1])), shape=(n_gp, n_hit)
+    )
+    calohit_to_cluster = coo_matrix(
+        (gpdata.hit_to_cluster[2], (gpdata.hit_to_cluster[0], gpdata.hit_to_cluster[1])), shape=(n_hit, n_cluster)
+    )
 
     gp_to_cluster = np.array((gp_to_calohit * calohit_to_cluster).todense())
 
@@ -840,7 +861,9 @@ def get_reco_properties(dataset, prop_data, iev):
         raise Exception("--dataset provided is not supported. Only 'fcc' or 'clic' are supported atm.")
 
     reco_p4 = vector.awk(
-        awkward.zip({"mass": reco_arr["mass"], "x": reco_arr["momentum.x"], "y": reco_arr["momentum.y"], "z": reco_arr["momentum.z"]})
+        awkward.zip(
+            {"mass": reco_arr["mass"], "x": reco_arr["momentum.x"], "y": reco_arr["momentum.y"], "z": reco_arr["momentum.z"]}
+        )
     )
     reco_arr["pt"] = reco_p4.pt
     reco_arr["eta"] = reco_p4.eta
@@ -1025,21 +1048,30 @@ def process_one_file(fn, ofn, dataset):
         calohit_links = arrs.arrays(
             [
                 "CalohitMCTruthLink.weight",
-                "_CalohitMCTruthLink_rec/_CalohitMCTruthLink_rec.collectionID",
-                "_CalohitMCTruthLink_rec/_CalohitMCTruthLink_rec.index",
-                "_CalohitMCTruthLink_sim/_CalohitMCTruthLink_sim.collectionID",
-                "_CalohitMCTruthLink_sim/_CalohitMCTruthLink_sim.index",
+                # "_CalohitMCTruthLink_rec/_CalohitMCTruthLink_rec.collectionID",
+                # "_CalohitMCTruthLink_rec/_CalohitMCTruthLink_rec.index",
+                # "_CalohitMCTruthLink_sim/_CalohitMCTruthLink_sim.collectionID",
+                # "_CalohitMCTruthLink_sim/_CalohitMCTruthLink_sim.index",
+                "_CalohitMCTruthLink_to/_CalohitMCTruthLink_to.collectionID",
+                "_CalohitMCTruthLink_to/_CalohitMCTruthLink_to.index",
+                "_CalohitMCTruthLink_from/_CalohitMCTruthLink_from.collectionID",
+                "_CalohitMCTruthLink_from/_CalohitMCTruthLink_from.index",
             ]
         )
         sitrack_links = arrs.arrays(
             [
                 "SiTracksMCTruthLink.weight",
-                "_SiTracksMCTruthLink_rec/_SiTracksMCTruthLink_rec.collectionID",
-                "_SiTracksMCTruthLink_rec/_SiTracksMCTruthLink_rec.index",
-                "_SiTracksMCTruthLink_sim/_SiTracksMCTruthLink_sim.collectionID",
-                "_SiTracksMCTruthLink_sim/_SiTracksMCTruthLink_sim.index",
+                # "_SiTracksMCTruthLink_rec/_SiTracksMCTruthLink_rec.collectionID",
+                # "_SiTracksMCTruthLink_rec/_SiTracksMCTruthLink_rec.index",
+                # "_SiTracksMCTruthLink_sim/_SiTracksMCTruthLink_sim.collectionID",
+                # "_SiTracksMCTruthLink_sim/_SiTracksMCTruthLink_sim.index",
+                "_SiTracksMCTruthLink_to/_SiTracksMCTruthLink_to.collectionID",
+                "_SiTracksMCTruthLink_to/_SiTracksMCTruthLink_to.index",
+                "_SiTracksMCTruthLink_from/_SiTracksMCTruthLink_from.collectionID",
+                "_SiTracksMCTruthLink_from/_SiTracksMCTruthLink_from.index",
             ]
         )
+
         # maps the recoparticle track/cluster index (in tracks_begin,end and clusters_begin,end)
         # to the index in the track/cluster collection
         idx_rp_to_cluster = arrs["_PandoraPFOs_clusters/_PandoraPFOs_clusters.index"].array()
@@ -1148,19 +1180,29 @@ def process_one_file(fn, ofn, dataset):
         assert np.all(used_rps == 1)
 
         gps_track = get_particle_feature_matrix(track_to_gp_all, gpdata_cleaned.gen_features, particle_feature_order)
-        gps_track[:, 0] = np.array([map_neutral_to_charged(map_pdgid_to_candid(p, c)) for p, c in zip(gps_track[:, 0], gps_track[:, 1])])
+        gps_track[:, 0] = np.array(
+            [map_neutral_to_charged(map_pdgid_to_candid(p, c)) for p, c in zip(gps_track[:, 0], gps_track[:, 1])]
+        )
         gps_cluster = get_particle_feature_matrix(cluster_to_gp_all, gpdata_cleaned.gen_features, particle_feature_order)
-        gps_cluster[:, 0] = np.array([map_charged_to_neutral(map_pdgid_to_candid(p, c)) for p, c in zip(gps_cluster[:, 0], gps_cluster[:, 1])])
+        gps_cluster[:, 0] = np.array(
+            [map_charged_to_neutral(map_pdgid_to_candid(p, c)) for p, c in zip(gps_cluster[:, 0], gps_cluster[:, 1])]
+        )
         gps_cluster[:, 1] = 0
 
         rps_track = get_particle_feature_matrix(track_to_rp_all, reco_features, particle_feature_order)
-        rps_track[:, 0] = np.array([map_neutral_to_charged(map_pdgid_to_candid(p, c)) for p, c in zip(rps_track[:, 0], rps_track[:, 1])])
+        rps_track[:, 0] = np.array(
+            [map_neutral_to_charged(map_pdgid_to_candid(p, c)) for p, c in zip(rps_track[:, 0], rps_track[:, 1])]
+        )
         rps_cluster = get_particle_feature_matrix(cluster_to_rp_all, reco_features, particle_feature_order)
-        rps_cluster[:, 0] = np.array([map_charged_to_neutral(map_pdgid_to_candid(p, c)) for p, c in zip(rps_cluster[:, 0], rps_cluster[:, 1])])
+        rps_cluster[:, 0] = np.array(
+            [map_charged_to_neutral(map_pdgid_to_candid(p, c)) for p, c in zip(rps_cluster[:, 0], rps_cluster[:, 1])]
+        )
         rps_cluster[:, 1] = 0
 
         # all initial gen/reco particle energy must be reconstructable
-        assert abs(np.sum(gps_track[:, 6]) + np.sum(gps_cluster[:, 6]) - np.sum(gpdata_cleaned.gen_features["energy"])) < 1e-2
+        assert (
+            abs(np.sum(gps_track[:, 6]) + np.sum(gps_cluster[:, 6]) - np.sum(gpdata_cleaned.gen_features["energy"])) < 1e-2
+        )
 
         assert abs(np.sum(rps_track[:, 6]) + np.sum(rps_cluster[:, 6]) - np.sum(reco_features["energy"])) < 1e-2
 
@@ -1207,7 +1249,9 @@ def process_one_file(fn, ofn, dataset):
         sorted_jet_idx = awkward.argsort(target_jets.pt, axis=-1, ascending=False).to_list()
         target_jets_indices = target_jets_indices.to_list()
         for jet_idx in sorted_jet_idx:
-            jet_constituents = [index_mapping[idx] for idx in target_jets_indices[jet_idx]]  # map back to constituent index *before* masking
+            jet_constituents = [
+                index_mapping[idx] for idx in target_jets_indices[jet_idx]
+            ]  # map back to constituent index *before* masking
             ytarget_constituents[jet_constituents] = jet_idx
         ytarget_track_constituents = ytarget_constituents[: len(ytarget_track)]
         ytarget_cluster_constituents = ytarget_constituents[len(ytarget_track) :]

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -507,6 +507,7 @@ def track_to_features(dataset, prop_data, iev):
         # ret["radiusOfInnermostHit"] = track_arr["SiTracks_Refitted_dQdx.dQdx.error"]  # TODO: fix
 
         num_tracks = len(track_arr["SiTracks_Refitted_dQdx.dQdx.value"])
+        print("num_tracks", num_tracks)
         innermost_radius = []
         for itrack in range(num_tracks):
 

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -182,9 +182,7 @@ class EventData:
         self.cluster_features = cluster_features  # feature matrix of the calo clusters
         self.track_features = track_features  # feature matrix of the tracks
         self.genparticle_to_hit = genparticle_to_hit  # sparse COO matrix of genparticles to hits (idx_gp, idx_hit, weight)
-        self.genparticle_to_track = (
-            genparticle_to_track  # sparse COO matrix of genparticles to tracks (idx_gp, idx_track, weight)
-        )
+        self.genparticle_to_track = genparticle_to_track  # sparse COO matrix of genparticles to tracks (idx_gp, idx_track, weight)
         self.hit_to_cluster = hit_to_cluster  # sparse COO matrix of hits to clusters (idx_hit, idx_cluster, weight)
         self.gp_merges = gp_merges  # sparse COO matrix of any merged genparticles
 
@@ -250,10 +248,7 @@ def get_calohit_matrix_and_genadj(dataset, hit_data, calohit_links, iev, collect
             hit_idx_global += 1
     hit_idx_local_to_global = {v: k for k, v in hit_idx_global_to_local.items()}
     hit_feature_matrix = awkward.Record(
-        {
-            k: awkward.concatenate([hit_feature_matrix[i][k] for i in range(len(hit_feature_matrix))])
-            for k in hit_feature_matrix[0].fields
-        }
+        {k: awkward.concatenate([hit_feature_matrix[i][k] for i in range(len(hit_feature_matrix))]) for k in hit_feature_matrix[0].fields}
     )
 
     # add all edges from genparticle to calohit
@@ -348,9 +343,7 @@ def gen_to_features(dataset, prop_data, iev):
     gen_arr = {k.replace(mc_coll + ".", ""): gen_arr[k] for k in gen_arr.fields}
 
     MCParticles_p4 = vector.awk(
-        awkward.zip(
-            {"mass": gen_arr["mass"], "x": gen_arr["momentum.x"], "y": gen_arr["momentum.y"], "z": gen_arr["momentum.z"]}
-        )
+        awkward.zip({"mass": gen_arr["mass"], "x": gen_arr["momentum.x"], "y": gen_arr["momentum.y"], "z": gen_arr["momentum.z"]})
     )
     gen_arr["pt"] = MCParticles_p4.pt
     gen_arr["eta"] = MCParticles_p4.eta
@@ -585,9 +578,7 @@ def add_daughters_to_status1(gen_features, genparticle_to_hit, genparticle_to_tr
 
 def get_genparticles_and_adjacencies(dataset, prop_data, hit_data, calohit_links, sitrack_links, iev, collectionIDs):
     gen_features = gen_to_features(dataset, prop_data, iev)
-    hit_features, genparticle_to_hit, hit_idx_local_to_global = get_calohit_matrix_and_genadj(
-        dataset, hit_data, calohit_links, iev, collectionIDs
-    )
+    hit_features, genparticle_to_hit, hit_idx_local_to_global = get_calohit_matrix_and_genadj(dataset, hit_data, calohit_links, iev, collectionIDs)
     hit_to_cluster = hit_cluster_adj(dataset, prop_data, hit_idx_local_to_global, iev)
     cluster_features = cluster_to_features(prop_data, hit_features, hit_to_cluster, iev)
     track_features = track_to_features(dataset, prop_data, iev)
@@ -597,9 +588,7 @@ def get_genparticles_and_adjacencies(dataset, prop_data, hit_data, calohit_links
     mask_status1 = gen_features["generatorStatus"] == 1
 
     if gen_features["index"] is not None:  # if there are even daughters
-        genparticle_to_hit, genparticle_to_trk = add_daughters_to_status1(
-            gen_features, genparticle_to_hit, genparticle_to_trk
-        )
+        genparticle_to_hit, genparticle_to_trk = add_daughters_to_status1(gen_features, genparticle_to_hit, genparticle_to_trk)
 
     n_gp = awkward.count(gen_features["PDG"])
     n_track = awkward.count(track_features["type"])
@@ -607,11 +596,7 @@ def get_genparticles_and_adjacencies(dataset, prop_data, hit_data, calohit_links
     n_cluster = awkward.count(cluster_features["type"])
 
     if len(genparticle_to_trk[0]) > 0:
-        gp_to_track = (
-            coo_matrix((genparticle_to_trk[2], (genparticle_to_trk[0], genparticle_to_trk[1])), shape=(n_gp, n_track))
-            .max(axis=1)
-            .todense()
-        )
+        gp_to_track = coo_matrix((genparticle_to_trk[2], (genparticle_to_trk[0], genparticle_to_trk[1])), shape=(n_gp, n_track)).max(axis=1).todense()
     else:
         gp_to_track = np.zeros((n_gp, 1))
 
@@ -641,9 +626,7 @@ def get_genparticles_and_adjacencies(dataset, prop_data, hit_data, calohit_links
 
     if len(np.array(mask_visible)) == 1:
         # event has only one particle (then index will be empty because no daughters)
-        gen_features = awkward.Record(
-            {feat: (gen_features[feat][mask_visible] if feat != "index" else None) for feat in gen_features.keys()}
-        )
+        gen_features = awkward.Record({feat: (gen_features[feat][mask_visible] if feat != "index" else None) for feat in gen_features.keys()})
     else:
         gen_features = awkward.Record({feat: gen_features[feat][mask_visible] for feat in gen_features.keys()})
 
@@ -676,12 +659,8 @@ def assign_genparticles_to_obj_and_merge(gpdata):
         ).todense()
     )
 
-    gp_to_calohit = coo_matrix(
-        (gpdata.genparticle_to_hit[2], (gpdata.genparticle_to_hit[0], gpdata.genparticle_to_hit[1])), shape=(n_gp, n_hit)
-    )
-    calohit_to_cluster = coo_matrix(
-        (gpdata.hit_to_cluster[2], (gpdata.hit_to_cluster[0], gpdata.hit_to_cluster[1])), shape=(n_hit, n_cluster)
-    )
+    gp_to_calohit = coo_matrix((gpdata.genparticle_to_hit[2], (gpdata.genparticle_to_hit[0], gpdata.genparticle_to_hit[1])), shape=(n_gp, n_hit))
+    calohit_to_cluster = coo_matrix((gpdata.hit_to_cluster[2], (gpdata.hit_to_cluster[0], gpdata.hit_to_cluster[1])), shape=(n_hit, n_cluster))
 
     gp_to_cluster = np.array((gp_to_calohit * calohit_to_cluster).todense())
 
@@ -861,9 +840,7 @@ def get_reco_properties(dataset, prop_data, iev):
         raise Exception("--dataset provided is not supported. Only 'fcc' or 'clic' are supported atm.")
 
     reco_p4 = vector.awk(
-        awkward.zip(
-            {"mass": reco_arr["mass"], "x": reco_arr["momentum.x"], "y": reco_arr["momentum.y"], "z": reco_arr["momentum.z"]}
-        )
+        awkward.zip({"mass": reco_arr["mass"], "x": reco_arr["momentum.x"], "y": reco_arr["momentum.y"], "z": reco_arr["momentum.z"]})
     )
     reco_arr["pt"] = reco_p4.pt
     reco_arr["eta"] = reco_p4.eta
@@ -1171,29 +1148,19 @@ def process_one_file(fn, ofn, dataset):
         assert np.all(used_rps == 1)
 
         gps_track = get_particle_feature_matrix(track_to_gp_all, gpdata_cleaned.gen_features, particle_feature_order)
-        gps_track[:, 0] = np.array(
-            [map_neutral_to_charged(map_pdgid_to_candid(p, c)) for p, c in zip(gps_track[:, 0], gps_track[:, 1])]
-        )
+        gps_track[:, 0] = np.array([map_neutral_to_charged(map_pdgid_to_candid(p, c)) for p, c in zip(gps_track[:, 0], gps_track[:, 1])])
         gps_cluster = get_particle_feature_matrix(cluster_to_gp_all, gpdata_cleaned.gen_features, particle_feature_order)
-        gps_cluster[:, 0] = np.array(
-            [map_charged_to_neutral(map_pdgid_to_candid(p, c)) for p, c in zip(gps_cluster[:, 0], gps_cluster[:, 1])]
-        )
+        gps_cluster[:, 0] = np.array([map_charged_to_neutral(map_pdgid_to_candid(p, c)) for p, c in zip(gps_cluster[:, 0], gps_cluster[:, 1])])
         gps_cluster[:, 1] = 0
 
         rps_track = get_particle_feature_matrix(track_to_rp_all, reco_features, particle_feature_order)
-        rps_track[:, 0] = np.array(
-            [map_neutral_to_charged(map_pdgid_to_candid(p, c)) for p, c in zip(rps_track[:, 0], rps_track[:, 1])]
-        )
+        rps_track[:, 0] = np.array([map_neutral_to_charged(map_pdgid_to_candid(p, c)) for p, c in zip(rps_track[:, 0], rps_track[:, 1])])
         rps_cluster = get_particle_feature_matrix(cluster_to_rp_all, reco_features, particle_feature_order)
-        rps_cluster[:, 0] = np.array(
-            [map_charged_to_neutral(map_pdgid_to_candid(p, c)) for p, c in zip(rps_cluster[:, 0], rps_cluster[:, 1])]
-        )
+        rps_cluster[:, 0] = np.array([map_charged_to_neutral(map_pdgid_to_candid(p, c)) for p, c in zip(rps_cluster[:, 0], rps_cluster[:, 1])])
         rps_cluster[:, 1] = 0
 
         # all initial gen/reco particle energy must be reconstructable
-        assert (
-            abs(np.sum(gps_track[:, 6]) + np.sum(gps_cluster[:, 6]) - np.sum(gpdata_cleaned.gen_features["energy"])) < 1e-2
-        )
+        assert abs(np.sum(gps_track[:, 6]) + np.sum(gps_cluster[:, 6]) - np.sum(gpdata_cleaned.gen_features["energy"])) < 1e-2
 
         assert abs(np.sum(rps_track[:, 6]) + np.sum(rps_cluster[:, 6]) - np.sum(reco_features["energy"])) < 1e-2
 
@@ -1240,9 +1207,7 @@ def process_one_file(fn, ofn, dataset):
         sorted_jet_idx = awkward.argsort(target_jets.pt, axis=-1, ascending=False).to_list()
         target_jets_indices = target_jets_indices.to_list()
         for jet_idx in sorted_jet_idx:
-            jet_constituents = [
-                index_mapping[idx] for idx in target_jets_indices[jet_idx]
-            ]  # map back to constituent index *before* masking
+            jet_constituents = [index_mapping[idx] for idx in target_jets_indices[jet_idx]]  # map back to constituent index *before* masking
             ytarget_constituents[jet_constituents] = jet_idx
         ytarget_track_constituents = ytarget_constituents[: len(ytarget_track)]
         ytarget_cluster_constituents = ytarget_constituents[len(ytarget_track) :]

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -513,7 +513,7 @@ def track_to_features(dataset, prop_data, iev):
             # select the track states corresponding to itrack
             # pick the state AtFirstHit
             # https://github.com/key4hep/EDM4hep/blob/fe5a54046a91a7e648d0b588960db7841aebc670/edm4hep.yaml#L220
-            print(prop_data["SiTracks_Refitted"].fields())
+            print(prop_data["SiTracks_Refitted"][0].fields())
             ibegin = prop_data["SiTracks_Refitted.trackStates_begin"].array()[iev][itrack]
             iend = prop_data["SiTracks_Refitted.trackStates_end"].array()[iev][itrack]
 

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -514,7 +514,11 @@ def track_to_features(dataset, prop_data, iev):
         if dataset == "clic":
             ret[k] = awkward.to_numpy(prop_data["SiTracks_1"]["SiTracks_1." + k][iev][trackstate_idx])
         elif dataset == "fcc":
-            ret[k] = awkward.to_numpy(prop_data["_SiTracks_trackStates"]["_SiTracks_trackStates." + k][iev][trackstate_idx])
+            # ret[k] = awkward.to_numpy(prop_data["_SiTracks_trackStates"]["_SiTracks_trackStates." + k][iev][trackstate_idx])
+            ret[k] = awkward.to_numpy(
+                prop_data["_SiTracks_Refitted_trackStates"]["_SiTracks_Refitted_trackStates." + k][iev][trackstate_idx]
+            )
+
         else:
             raise Exception("--dataset provided is not supported. Only 'fcc' or 'clic' are supported atm.")
 
@@ -1055,7 +1059,8 @@ def process_one_file(fn, ofn, dataset):
                 "MCParticles.daughters_end",
                 "_MCParticles_daughters/_MCParticles_daughters.index",  # similar to "MCParticles#1.index" in clic
                 track_coll,
-                "_SiTracks_trackStates",
+                # "_SiTracks_trackStates",
+                "_SiTracks_Refitted_trackStates",
                 "PandoraClusters",
                 "_PandoraClusters_hits/_PandoraClusters_hits.index",
                 "_PandoraClusters_hits/_PandoraClusters_hits.collectionID",

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -514,16 +514,14 @@ def track_to_features(dataset, prop_data, iev):
             # pick the state AtFirstHit
             # https://github.com/key4hep/EDM4hep/blob/fe5a54046a91a7e648d0b588960db7841aebc670/edm4hep.yaml#L220
             track_arr = prop_data[track_coll][iev]
-            print(track_arr)
-            print(track_coll + "." + "trackStates_begin")
 
-            ibegin = track_arr[track_coll + "." + "trackStates_begin"].array()[iev][itrack]
-            iend = track_arr[track_coll + "." + "trackStates_end"].array()[iev][itrack]
+            ibegin = track_arr[track_coll + "." + "trackStates_begin"][itrack]
+            iend = track_arr[track_coll + "." + "trackStates_end"][itrack]
 
             track_arr = prop_data["_SiTracks_Refitted_trackStates"][iev]
-            refX = track_arr["_SiTracks_Refitted_trackStates" + "." + "referencePoint.x"].array()[iev][ibegin:iend]
-            refY = track_arr["_SiTracks_Refitted_trackStates" + "." + "referencePoint.y"].array()[iev][ibegin:iend]
-            location = track_arr["_SiTracks_Refitted_trackStates" + "." + "location"].array()[iev][ibegin:iend]
+            refX = track_arr["_SiTracks_Refitted_trackStates" + "." + "referencePoint.x"][ibegin:iend]
+            refY = track_arr["_SiTracks_Refitted_trackStates" + "." + "referencePoint.y"][ibegin:iend]
+            location = track_arr["_SiTracks_Refitted_trackStates" + "." + "location"][ibegin:iend]
 
             istate = np.argmax(location == 2)  # 2 refers to AtFirstHit
 

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -498,9 +498,9 @@ def track_to_features(dataset, prop_data, iev):
     ret = {feat: track_arr[track_coll + "." + feat] for feat in feats_from_track}
 
     track_arr = prop_data["SiTracks_Refitted_dQdx"][iev]
-    ret["dEdx"] = track_arr["SiTracks_Refitted_dQdx/SiTracks_Refitted_dQdx.dQdx.value"]
-    ret["dEdxError"] = track_arr["SiTracks_Refitted_dQdx/SiTracks_Refitted_dQdx.dQdx.error"]
-    ret["radiusOfInnermostHit"] = track_arr["SiTracks_Refitted/SiTracks_Refitted.Nholes"]  # TODO: fix
+    ret["dEdx"] = track_arr["SiTracks_Refitted_dQdx.dQdx.value"]
+    ret["dEdxError"] = track_arr["SiTracks_Refitted_dQdx.dQdx.error"]
+    ret["radiusOfInnermostHit"] = track_arr["SiTracks_Refitted.Nholes"]  # TODO: fix
 
     n_tr = len(ret["type"])
 

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -500,7 +500,7 @@ def track_to_features(dataset, prop_data, iev):
     track_arr = prop_data["SiTracks_Refitted_dQdx"][iev]
     ret["dEdx"] = track_arr["SiTracks_Refitted_dQdx.dQdx.value"]
     ret["dEdxError"] = track_arr["SiTracks_Refitted_dQdx.dQdx.error"]
-    ret["radiusOfInnermostHit"] = track_arr["SiTracks_Refitted.error"]  # TODO: fix
+    ret["radiusOfInnermostHit"] = track_arr["SiTracks_Refitted_dQdx.dQdx.error"]  # TODO: fix
 
     n_tr = len(ret["type"])
 

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -507,7 +507,6 @@ def track_to_features(dataset, prop_data, iev):
         # ret["radiusOfInnermostHit"] = track_arr["SiTracks_Refitted_dQdx.dQdx.error"]  # TODO: fix
 
         num_tracks = len(track_arr["SiTracks_Refitted_dQdx.dQdx.value"])
-        print("num_tracks", num_tracks)
         innermost_radius = []
         for itrack in range(num_tracks):
 
@@ -515,6 +514,9 @@ def track_to_features(dataset, prop_data, iev):
             # pick the state AtFirstHit
             # https://github.com/key4hep/EDM4hep/blob/fe5a54046a91a7e648d0b588960db7841aebc670/edm4hep.yaml#L220
             track_arr = prop_data[track_coll][iev]
+            print(track_arr)
+            print(track_coll + "." + "trackStates_begin")
+
             ibegin = track_arr[track_coll + "." + "trackStates_begin"].array()[iev][itrack]
             iend = track_arr[track_coll + "." + "trackStates_end"].array()[iev][itrack]
 

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -182,7 +182,9 @@ class EventData:
         self.cluster_features = cluster_features  # feature matrix of the calo clusters
         self.track_features = track_features  # feature matrix of the tracks
         self.genparticle_to_hit = genparticle_to_hit  # sparse COO matrix of genparticles to hits (idx_gp, idx_hit, weight)
-        self.genparticle_to_track = genparticle_to_track  # sparse COO matrix of genparticles to tracks (idx_gp, idx_track, weight)
+        self.genparticle_to_track = (
+            genparticle_to_track  # sparse COO matrix of genparticles to tracks (idx_gp, idx_track, weight)
+        )
         self.hit_to_cluster = hit_to_cluster  # sparse COO matrix of hits to clusters (idx_hit, idx_cluster, weight)
         self.gp_merges = gp_merges  # sparse COO matrix of any merged genparticles
 
@@ -248,7 +250,10 @@ def get_calohit_matrix_and_genadj(dataset, hit_data, calohit_links, iev, collect
             hit_idx_global += 1
     hit_idx_local_to_global = {v: k for k, v in hit_idx_global_to_local.items()}
     hit_feature_matrix = awkward.Record(
-        {k: awkward.concatenate([hit_feature_matrix[i][k] for i in range(len(hit_feature_matrix))]) for k in hit_feature_matrix[0].fields}
+        {
+            k: awkward.concatenate([hit_feature_matrix[i][k] for i in range(len(hit_feature_matrix))])
+            for k in hit_feature_matrix[0].fields
+        }
     )
 
     # add all edges from genparticle to calohit
@@ -343,7 +348,9 @@ def gen_to_features(dataset, prop_data, iev):
     gen_arr = {k.replace(mc_coll + ".", ""): gen_arr[k] for k in gen_arr.fields}
 
     MCParticles_p4 = vector.awk(
-        awkward.zip({"mass": gen_arr["mass"], "x": gen_arr["momentum.x"], "y": gen_arr["momentum.y"], "z": gen_arr["momentum.z"]})
+        awkward.zip(
+            {"mass": gen_arr["mass"], "x": gen_arr["momentum.x"], "y": gen_arr["momentum.y"], "z": gen_arr["momentum.z"]}
+        )
     )
     gen_arr["pt"] = MCParticles_p4.pt
     gen_arr["eta"] = MCParticles_p4.eta
@@ -578,7 +585,9 @@ def add_daughters_to_status1(gen_features, genparticle_to_hit, genparticle_to_tr
 
 def get_genparticles_and_adjacencies(dataset, prop_data, hit_data, calohit_links, sitrack_links, iev, collectionIDs):
     gen_features = gen_to_features(dataset, prop_data, iev)
-    hit_features, genparticle_to_hit, hit_idx_local_to_global = get_calohit_matrix_and_genadj(dataset, hit_data, calohit_links, iev, collectionIDs)
+    hit_features, genparticle_to_hit, hit_idx_local_to_global = get_calohit_matrix_and_genadj(
+        dataset, hit_data, calohit_links, iev, collectionIDs
+    )
     hit_to_cluster = hit_cluster_adj(dataset, prop_data, hit_idx_local_to_global, iev)
     cluster_features = cluster_to_features(prop_data, hit_features, hit_to_cluster, iev)
     track_features = track_to_features(dataset, prop_data, iev)
@@ -594,7 +603,11 @@ def get_genparticles_and_adjacencies(dataset, prop_data, hit_data, calohit_links
     n_cluster = awkward.count(cluster_features["type"])
 
     if len(genparticle_to_trk[0]) > 0:
-        gp_to_track = coo_matrix((genparticle_to_trk[2], (genparticle_to_trk[0], genparticle_to_trk[1])), shape=(n_gp, n_track)).max(axis=1).todense()
+        gp_to_track = (
+            coo_matrix((genparticle_to_trk[2], (genparticle_to_trk[0], genparticle_to_trk[1])), shape=(n_gp, n_track))
+            .max(axis=1)
+            .todense()
+        )
     else:
         gp_to_track = np.zeros((n_gp, 1))
 
@@ -618,6 +631,7 @@ def get_genparticles_and_adjacencies(dataset, prop_data, hit_data, calohit_links
     idx_all_masked = np.where(mask_visible)[0]
     genpart_idx_all_to_filtered = {idx_all: idx_filtered for idx_filtered, idx_all in enumerate(idx_all_masked)}
 
+    print("gen_features", gen_features.keys())
     gen_features = awkward.Record({feat: gen_features[feat][mask_visible] for feat in gen_features.keys()})
 
     genparticle_to_hit = filter_adj(genparticle_to_hit, genpart_idx_all_to_filtered)
@@ -649,8 +663,12 @@ def assign_genparticles_to_obj_and_merge(gpdata):
         ).todense()
     )
 
-    gp_to_calohit = coo_matrix((gpdata.genparticle_to_hit[2], (gpdata.genparticle_to_hit[0], gpdata.genparticle_to_hit[1])), shape=(n_gp, n_hit))
-    calohit_to_cluster = coo_matrix((gpdata.hit_to_cluster[2], (gpdata.hit_to_cluster[0], gpdata.hit_to_cluster[1])), shape=(n_hit, n_cluster))
+    gp_to_calohit = coo_matrix(
+        (gpdata.genparticle_to_hit[2], (gpdata.genparticle_to_hit[0], gpdata.genparticle_to_hit[1])), shape=(n_gp, n_hit)
+    )
+    calohit_to_cluster = coo_matrix(
+        (gpdata.hit_to_cluster[2], (gpdata.hit_to_cluster[0], gpdata.hit_to_cluster[1])), shape=(n_hit, n_cluster)
+    )
 
     gp_to_cluster = np.array((gp_to_calohit * calohit_to_cluster).todense())
 
@@ -830,7 +848,9 @@ def get_reco_properties(dataset, prop_data, iev):
         raise Exception("--dataset provided is not supported. Only 'fcc' or 'clic' are supported atm.")
 
     reco_p4 = vector.awk(
-        awkward.zip({"mass": reco_arr["mass"], "x": reco_arr["momentum.x"], "y": reco_arr["momentum.y"], "z": reco_arr["momentum.z"]})
+        awkward.zip(
+            {"mass": reco_arr["mass"], "x": reco_arr["momentum.x"], "y": reco_arr["momentum.y"], "z": reco_arr["momentum.z"]}
+        )
     )
     reco_arr["pt"] = reco_p4.pt
     reco_arr["eta"] = reco_p4.eta
@@ -1136,19 +1156,29 @@ def process_one_file(fn, ofn, dataset):
         assert np.all(used_rps == 1)
 
         gps_track = get_particle_feature_matrix(track_to_gp_all, gpdata_cleaned.gen_features, particle_feature_order)
-        gps_track[:, 0] = np.array([map_neutral_to_charged(map_pdgid_to_candid(p, c)) for p, c in zip(gps_track[:, 0], gps_track[:, 1])])
+        gps_track[:, 0] = np.array(
+            [map_neutral_to_charged(map_pdgid_to_candid(p, c)) for p, c in zip(gps_track[:, 0], gps_track[:, 1])]
+        )
         gps_cluster = get_particle_feature_matrix(cluster_to_gp_all, gpdata_cleaned.gen_features, particle_feature_order)
-        gps_cluster[:, 0] = np.array([map_charged_to_neutral(map_pdgid_to_candid(p, c)) for p, c in zip(gps_cluster[:, 0], gps_cluster[:, 1])])
+        gps_cluster[:, 0] = np.array(
+            [map_charged_to_neutral(map_pdgid_to_candid(p, c)) for p, c in zip(gps_cluster[:, 0], gps_cluster[:, 1])]
+        )
         gps_cluster[:, 1] = 0
 
         rps_track = get_particle_feature_matrix(track_to_rp_all, reco_features, particle_feature_order)
-        rps_track[:, 0] = np.array([map_neutral_to_charged(map_pdgid_to_candid(p, c)) for p, c in zip(rps_track[:, 0], rps_track[:, 1])])
+        rps_track[:, 0] = np.array(
+            [map_neutral_to_charged(map_pdgid_to_candid(p, c)) for p, c in zip(rps_track[:, 0], rps_track[:, 1])]
+        )
         rps_cluster = get_particle_feature_matrix(cluster_to_rp_all, reco_features, particle_feature_order)
-        rps_cluster[:, 0] = np.array([map_charged_to_neutral(map_pdgid_to_candid(p, c)) for p, c in zip(rps_cluster[:, 0], rps_cluster[:, 1])])
+        rps_cluster[:, 0] = np.array(
+            [map_charged_to_neutral(map_pdgid_to_candid(p, c)) for p, c in zip(rps_cluster[:, 0], rps_cluster[:, 1])]
+        )
         rps_cluster[:, 1] = 0
 
         # all initial gen/reco particle energy must be reconstructable
-        assert abs(np.sum(gps_track[:, 6]) + np.sum(gps_cluster[:, 6]) - np.sum(gpdata_cleaned.gen_features["energy"])) < 1e-2
+        assert (
+            abs(np.sum(gps_track[:, 6]) + np.sum(gps_cluster[:, 6]) - np.sum(gpdata_cleaned.gen_features["energy"])) < 1e-2
+        )
 
         assert abs(np.sum(rps_track[:, 6]) + np.sum(rps_cluster[:, 6]) - np.sum(reco_features["energy"])) < 1e-2
 
@@ -1195,7 +1225,9 @@ def process_one_file(fn, ofn, dataset):
         sorted_jet_idx = awkward.argsort(target_jets.pt, axis=-1, ascending=False).to_list()
         target_jets_indices = target_jets_indices.to_list()
         for jet_idx in sorted_jet_idx:
-            jet_constituents = [index_mapping[idx] for idx in target_jets_indices[jet_idx]]  # map back to constituent index *before* masking
+            jet_constituents = [
+                index_mapping[idx] for idx in target_jets_indices[jet_idx]
+            ]  # map back to constituent index *before* masking
             ytarget_constituents[jet_constituents] = jet_idx
         ytarget_track_constituents = ytarget_constituents[: len(ytarget_track)]
         ytarget_cluster_constituents = ytarget_constituents[len(ytarget_track) :]

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -498,30 +498,29 @@ def track_to_features(dataset, prop_data, iev):
 
     elif dataset == "fcc":
         track_arr = prop_data[track_coll][iev]
+        # the following are needed since they are no longer defined under SiTracks_Refitted
+        track_arr_dQdx = prop_data["SiTracks_Refitted_dQdx"][iev]
+        track_arr_trackStates = prop_data["_SiTracks_Refitted_trackStates"][iev]
+
         feats_from_track = ["type", "chi2", "ndf"]
         ret = {feat: track_arr[track_coll + "." + feat] for feat in feats_from_track}
 
-        track_arr = prop_data["SiTracks_Refitted_dQdx"][iev]
-        ret["dEdx"] = track_arr["SiTracks_Refitted_dQdx.dQdx.value"]
-        ret["dEdxError"] = track_arr["SiTracks_Refitted_dQdx.dQdx.error"]
-        # ret["radiusOfInnermostHit"] = track_arr["SiTracks_Refitted_dQdx.dQdx.error"]  # TODO: fix
+        ret["dEdx"] = track_arr_dQdx["SiTracks_Refitted_dQdx.dQdx.value"]
+        ret["dEdxError"] = track_arr_dQdx["SiTracks_Refitted_dQdx.dQdx.error"]
 
-        num_tracks = len(track_arr["SiTracks_Refitted_dQdx.dQdx.value"])
+        num_tracks = len(track_arr_dQdx["SiTracks_Refitted_dQdx.dQdx.value"])
         innermost_radius = []
         for itrack in range(num_tracks):
 
             # select the track states corresponding to itrack
             # pick the state AtFirstHit
             # https://github.com/key4hep/EDM4hep/blob/fe5a54046a91a7e648d0b588960db7841aebc670/edm4hep.yaml#L220
-            track_arr = prop_data[track_coll][iev]
-
             ibegin = track_arr[track_coll + "." + "trackStates_begin"][itrack]
             iend = track_arr[track_coll + "." + "trackStates_end"][itrack]
 
-            track_arr = prop_data["_SiTracks_Refitted_trackStates"][iev]
-            refX = track_arr["_SiTracks_Refitted_trackStates" + "." + "referencePoint.x"][ibegin:iend]
-            refY = track_arr["_SiTracks_Refitted_trackStates" + "." + "referencePoint.y"][ibegin:iend]
-            location = track_arr["_SiTracks_Refitted_trackStates" + "." + "location"][ibegin:iend]
+            refX = track_arr_trackStates["_SiTracks_Refitted_trackStates" + "." + "referencePoint.x"][ibegin:iend]
+            refY = track_arr_trackStates["_SiTracks_Refitted_trackStates" + "." + "referencePoint.y"][ibegin:iend]
+            location = track_arr_trackStates["_SiTracks_Refitted_trackStates" + "." + "location"][ibegin:iend]
 
             istate = np.argmax(location == 2)  # 2 refers to AtFirstHit
 

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -631,11 +631,11 @@ def get_genparticles_and_adjacencies(dataset, prop_data, hit_data, calohit_links
     idx_all_masked = np.where(mask_visible)[0]
     genpart_idx_all_to_filtered = {idx_all: idx_filtered for idx_filtered, idx_all in enumerate(idx_all_masked)}
 
-    print("mask_visible", mask_visible)
-    if mask_visible.sum() == 0:
+    print("mask_visible", np.array(mask_visible))
+    if np.array(mask_visible).sum() == 0:
         return None
     else:
-        print("mask_visible.sum()", mask_visible.sum())
+        print("mask_visible.sum()", np.array(mask_visible).sum())
 
     gen_features = awkward.Record({feat: gen_features[feat][mask_visible] for feat in gen_features.keys()})
 

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -489,11 +489,11 @@ def cluster_to_features(prop_data, hit_features, hit_to_cluster, iev):
 
 
 def track_to_features(dataset, prop_data, iev):
-    track_arr = prop_data[track_coll][iev]
-
+    # track_arr = prop_data[track_coll][iev]
     # feats_from_track = ["type", "chi2", "ndf", "dEdx", "dEdxError", "radiusOfInnermostHit"]
     # ret = {feat: track_arr[track_coll + "." + feat] for feat in feats_from_track}
 
+    track_arr = prop_data[[track_coll] + ["SiTracks_Refitted_dQdx"]][iev]
     feats_from_track = ["type", "chi2", "ndf"]
     ret = {feat: track_arr[track_coll + "." + feat] for feat in feats_from_track}
 

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -499,7 +499,7 @@ def track_to_features(dataset, prop_data, iev):
 
     ret["dEdx"] = track_arr["SiTracks_Refitted_dQdx/SiTracks_Refitted_dQdx.dQdx.value"]
     ret["dEdxError"] = track_arr["SiTracks_Refitted_dQdx/SiTracks_Refitted_dQdx.dQdx.error"]
-    ret["radiusOfInnermostHit"] = track_arr["SiTracks_Refitted/SiTracks_Refitted.Nholes"] # TODO: fix
+    ret["radiusOfInnermostHit"] = track_arr["SiTracks_Refitted/SiTracks_Refitted.Nholes"]  # TODO: fix
 
     n_tr = len(ret["type"])
 
@@ -1057,6 +1057,7 @@ def process_one_file(fn, ofn, dataset):
                 "_PandoraClusters_hits/_PandoraClusters_hits.index",
                 "_PandoraClusters_hits/_PandoraClusters_hits.collectionID",
                 "PandoraPFOs",
+                "SiTracks_Refitted_dQdx",  # TODO: new
             ]
         )
         calohit_links = arrs.arrays(

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -631,11 +631,9 @@ def get_genparticles_and_adjacencies(dataset, prop_data, hit_data, calohit_links
     idx_all_masked = np.where(mask_visible)[0]
     genpart_idx_all_to_filtered = {idx_all: idx_filtered for idx_filtered, idx_all in enumerate(idx_all_masked)}
 
-    print("mask_visible", np.array(mask_visible))
+    print("mask_visible.sum()", np.array(mask_visible).sum())
     if np.array(mask_visible).sum() == 0:
         return None
-    else:
-        print("mask_visible.sum()", np.array(mask_visible).sum())
 
     gen_features = awkward.Record({feat: gen_features[feat][mask_visible] for feat in gen_features.keys()})
 

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -635,7 +635,7 @@ def get_genparticles_and_adjacencies(dataset, prop_data, hit_data, calohit_links
         print("hop")
         return None
     print(mask_visible.shape)
-
+    mask_visible = mask_visible.reshape(-1, 1)
     gen_features = awkward.Record({feat: gen_features[feat][mask_visible] for feat in gen_features.keys()})
 
     genparticle_to_hit = filter_adj(genparticle_to_hit, genpart_idx_all_to_filtered)

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -634,6 +634,7 @@ def get_genparticles_and_adjacencies(dataset, prop_data, hit_data, calohit_links
     if np.array(mask_visible).sum() == 0:
         print("hop")
         return None
+    print(mask_visible.shape)
 
     gen_features = awkward.Record({feat: gen_features[feat][mask_visible] for feat in gen_features.keys()})
 

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -495,7 +495,6 @@ def track_to_features(dataset, prop_data, iev):
 
     track_arr = prop_data[[track_coll] + ["SiTracks_Refitted_dQdx"]][iev]
     feats_from_track = ["type", "chi2", "ndf"]
-    ret = {feat: track_arr[track_coll + "." + feat] for feat in feats_from_track}
     ret = {feat: track_arr[track_coll + "/" + track_coll + "." + feat] for feat in feats_from_track}
 
     ret["dEdx"] = track_arr["SiTracks_Refitted_dQdx/SiTracks_Refitted_dQdx.dQdx.value"]

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -272,7 +272,7 @@ def get_calohit_matrix_and_genadj(dataset, hit_data, calohit_links, iev, collect
         calohit_to_gen_calo_colid = calohit_links["_CalohitMCTruthLink_from/_CalohitMCTruthLink_from.collectionID"][iev]
         calohit_to_gen_gen_colid = calohit_links["_CalohitMCTruthLink_to/_CalohitMCTruthLink_to.collectionID"][iev]
         calohit_to_gen_calo_idx = calohit_links["_CalohitMCTruthLink_from/_CalohitMCTruthLink_from.index"][iev]
-        calohit_to_gen_gen_idx = calohit_links["_CalohitMCTruthLink_to/_CalohitMCTruthLink_to.index"][iev]        
+        calohit_to_gen_gen_idx = calohit_links["_CalohitMCTruthLink_to/_CalohitMCTruthLink_to.index"][iev]
     else:
         raise Exception("--dataset provided is not supported. Only 'fcc' or 'clic' are supported atm.")
 
@@ -490,8 +490,17 @@ def cluster_to_features(prop_data, hit_features, hit_to_cluster, iev):
 
 def track_to_features(dataset, prop_data, iev):
     track_arr = prop_data[track_coll][iev]
-    feats_from_track = ["type", "chi2", "ndf", "dEdx", "dEdxError", "radiusOfInnermostHit"]
+
+    # feats_from_track = ["type", "chi2", "ndf", "dEdx", "dEdxError", "radiusOfInnermostHit"]
+    # ret = {feat: track_arr[track_coll + "." + feat] for feat in feats_from_track}
+
+    feats_from_track = ["type", "chi2", "ndf"]
     ret = {feat: track_arr[track_coll + "." + feat] for feat in feats_from_track}
+
+    ret["dEdx"] = track_arr["SiTracks_Refitted_dQdx/SiTracks_Refitted_dQdx.dQdx.value"]
+    ret["dEdxError"] = track_arr["SiTracks_Refitted_dQdx/SiTracks_Refitted_dQdx.dQdx.error"]
+    ret["radiusOfInnermostHit"] = track_arr["SiTracks_Refitted/SiTracks_Refitted.Nholes"] # TODO: fix
+
     n_tr = len(ret["type"])
 
     # get the index of the first track state

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -638,7 +638,8 @@ def get_genparticles_and_adjacencies(dataset, prop_data, hit_data, calohit_links
     for feat in gen_features.keys():
         print("feat", gen_features[feat].to_numpy().shape, gen_features[feat].to_numpy())
         break
-    # if len(mask_visible) == 1:
+    if len(np.array(mask_visible)) == 1:
+        return None
 
     gen_features = awkward.Record({feat: gen_features[feat][mask_visible] for feat in gen_features.keys()})
 

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -494,6 +494,11 @@ def track_to_features(dataset, prop_data, iev):
     # ret = {feat: track_arr[track_coll + "." + feat] for feat in feats_from_track}
 
     track_arr = prop_data[[track_coll] + ["SiTracks_Refitted_dQdx"]][iev]
+    print("track_arr", track_arr)
+
+    track_arr = prop_data[track_coll][iev]
+    print("track_arr", track_arr)
+
     feats_from_track = ["type", "chi2", "ndf"]
     ret = {feat: track_arr[track_coll + "/" + track_coll + "." + feat] for feat in feats_from_track}
 

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -182,7 +182,9 @@ class EventData:
         self.cluster_features = cluster_features  # feature matrix of the calo clusters
         self.track_features = track_features  # feature matrix of the tracks
         self.genparticle_to_hit = genparticle_to_hit  # sparse COO matrix of genparticles to hits (idx_gp, idx_hit, weight)
-        self.genparticle_to_track = genparticle_to_track  # sparse COO matrix of genparticles to tracks (idx_gp, idx_track, weight)
+        self.genparticle_to_track = (
+            genparticle_to_track  # sparse COO matrix of genparticles to tracks (idx_gp, idx_track, weight)
+        )
         self.hit_to_cluster = hit_to_cluster  # sparse COO matrix of hits to clusters (idx_hit, idx_cluster, weight)
         self.gp_merges = gp_merges  # sparse COO matrix of any merged genparticles
 
@@ -248,7 +250,10 @@ def get_calohit_matrix_and_genadj(dataset, hit_data, calohit_links, iev, collect
             hit_idx_global += 1
     hit_idx_local_to_global = {v: k for k, v in hit_idx_global_to_local.items()}
     hit_feature_matrix = awkward.Record(
-        {k: awkward.concatenate([hit_feature_matrix[i][k] for i in range(len(hit_feature_matrix))]) for k in hit_feature_matrix[0].fields}
+        {
+            k: awkward.concatenate([hit_feature_matrix[i][k] for i in range(len(hit_feature_matrix))])
+            for k in hit_feature_matrix[0].fields
+        }
     )
 
     # add all edges from genparticle to calohit
@@ -259,11 +264,6 @@ def get_calohit_matrix_and_genadj(dataset, hit_data, calohit_links, iev, collect
         calohit_to_gen_calo_idx = calohit_links["CalohitMCTruthLink#0.index"][iev]
         calohit_to_gen_gen_idx = calohit_links["CalohitMCTruthLink#1.index"][iev]
     elif dataset == "fcc":
-        # calohit_to_gen_calo_colid = calohit_links["_CalohitMCTruthLink_rec/_CalohitMCTruthLink_rec.collectionID"][iev]
-        # calohit_to_gen_gen_colid = calohit_links["_CalohitMCTruthLink_sim/_CalohitMCTruthLink_sim.collectionID"][iev]
-        # calohit_to_gen_calo_idx = calohit_links["_CalohitMCTruthLink_rec/_CalohitMCTruthLink_rec.index"][iev]
-        # calohit_to_gen_gen_idx = calohit_links["_CalohitMCTruthLink_sim/_CalohitMCTruthLink_sim.index"][iev]
-
         calohit_to_gen_calo_colid = calohit_links["_CalohitMCTruthLink_from/_CalohitMCTruthLink_from.collectionID"][iev]
         calohit_to_gen_gen_colid = calohit_links["_CalohitMCTruthLink_to/_CalohitMCTruthLink_to.collectionID"][iev]
         calohit_to_gen_calo_idx = calohit_links["_CalohitMCTruthLink_from/_CalohitMCTruthLink_from.index"][iev]
@@ -348,7 +348,9 @@ def gen_to_features(dataset, prop_data, iev):
     gen_arr = {k.replace(mc_coll + ".", ""): gen_arr[k] for k in gen_arr.fields}
 
     MCParticles_p4 = vector.awk(
-        awkward.zip({"mass": gen_arr["mass"], "x": gen_arr["momentum.x"], "y": gen_arr["momentum.y"], "z": gen_arr["momentum.z"]})
+        awkward.zip(
+            {"mass": gen_arr["mass"], "x": gen_arr["momentum.x"], "y": gen_arr["momentum.y"], "z": gen_arr["momentum.z"]}
+        )
     )
     gen_arr["pt"] = MCParticles_p4.pt
     gen_arr["eta"] = MCParticles_p4.eta
@@ -395,8 +397,6 @@ def genparticle_track_adj(dataset, sitrack_links, iev):
         trk_to_gen_trkidx = sitrack_links["SiTracksMCTruthLink#0.index"][iev]
         trk_to_gen_genidx = sitrack_links["SiTracksMCTruthLink#1.index"][iev]
     elif dataset == "fcc":
-        # trk_to_gen_trkidx = sitrack_links["_SiTracksMCTruthLink_rec/_SiTracksMCTruthLink_rec.index"][iev]
-        # trk_to_gen_genidx = sitrack_links["_SiTracksMCTruthLink_sim/_SiTracksMCTruthLink_sim.index"][iev]
         trk_to_gen_trkidx = sitrack_links["_SiTracksMCTruthLink_from/_SiTracksMCTruthLink_from.index"][iev]
         trk_to_gen_genidx = sitrack_links["_SiTracksMCTruthLink_to/_SiTracksMCTruthLink_to.index"][iev]
     else:
@@ -501,7 +501,8 @@ def track_to_features(dataset, prop_data, iev):
         ret["dEdx"] = track_arr_dQdx["SiTracks_Refitted_dQdx.dQdx.value"]
         ret["dEdxError"] = track_arr_dQdx["SiTracks_Refitted_dQdx.dQdx.error"]
 
-        num_tracks = len(track_arr_dQdx["SiTracks_Refitted_dQdx.dQdx.value"])
+        # build the radiusOfInnermostHit variable
+        num_tracks = len(ret["dEdx"])
         innermost_radius = []
         for itrack in range(num_tracks):
 
@@ -534,8 +535,9 @@ def track_to_features(dataset, prop_data, iev):
         if dataset == "clic":
             ret[k] = awkward.to_numpy(prop_data["SiTracks_1"]["SiTracks_1." + k][iev][trackstate_idx])
         elif dataset == "fcc":
-            # ret[k] = awkward.to_numpy(prop_data["_SiTracks_trackStates"]["_SiTracks_trackStates." + k][iev][trackstate_idx])
-            ret[k] = awkward.to_numpy(prop_data["_SiTracks_Refitted_trackStates"]["_SiTracks_Refitted_trackStates." + k][iev][trackstate_idx])
+            ret[k] = awkward.to_numpy(
+                prop_data["_SiTracks_Refitted_trackStates"]["_SiTracks_Refitted_trackStates." + k][iev][trackstate_idx]
+            )
 
         else:
             raise Exception("--dataset provided is not supported. Only 'fcc' or 'clic' are supported atm.")
@@ -624,7 +626,9 @@ def add_daughters_to_status1(gen_features, genparticle_to_hit, genparticle_to_tr
 
 def get_genparticles_and_adjacencies(dataset, prop_data, hit_data, calohit_links, sitrack_links, iev, collectionIDs):
     gen_features = gen_to_features(dataset, prop_data, iev)
-    hit_features, genparticle_to_hit, hit_idx_local_to_global = get_calohit_matrix_and_genadj(dataset, hit_data, calohit_links, iev, collectionIDs)
+    hit_features, genparticle_to_hit, hit_idx_local_to_global = get_calohit_matrix_and_genadj(
+        dataset, hit_data, calohit_links, iev, collectionIDs
+    )
     hit_to_cluster = hit_cluster_adj(dataset, prop_data, hit_idx_local_to_global, iev)
     cluster_features = cluster_to_features(prop_data, hit_features, hit_to_cluster, iev)
     track_features = track_to_features(dataset, prop_data, iev)
@@ -634,7 +638,9 @@ def get_genparticles_and_adjacencies(dataset, prop_data, hit_data, calohit_links
     mask_status1 = gen_features["generatorStatus"] == 1
 
     if gen_features["index"] is not None:  # if there are even daughters
-        genparticle_to_hit, genparticle_to_trk = add_daughters_to_status1(gen_features, genparticle_to_hit, genparticle_to_trk)
+        genparticle_to_hit, genparticle_to_trk = add_daughters_to_status1(
+            gen_features, genparticle_to_hit, genparticle_to_trk
+        )
 
     n_gp = awkward.count(gen_features["PDG"])
     n_track = awkward.count(track_features["type"])
@@ -642,7 +648,11 @@ def get_genparticles_and_adjacencies(dataset, prop_data, hit_data, calohit_links
     n_cluster = awkward.count(cluster_features["type"])
 
     if len(genparticle_to_trk[0]) > 0:
-        gp_to_track = coo_matrix((genparticle_to_trk[2], (genparticle_to_trk[0], genparticle_to_trk[1])), shape=(n_gp, n_track)).max(axis=1).todense()
+        gp_to_track = (
+            coo_matrix((genparticle_to_trk[2], (genparticle_to_trk[0], genparticle_to_trk[1])), shape=(n_gp, n_track))
+            .max(axis=1)
+            .todense()
+        )
     else:
         gp_to_track = np.zeros((n_gp, 1))
 
@@ -672,7 +682,9 @@ def get_genparticles_and_adjacencies(dataset, prop_data, hit_data, calohit_links
 
     if len(np.array(mask_visible)) == 1:
         # event has only one particle (then index will be empty because no daughters)
-        gen_features = awkward.Record({feat: (gen_features[feat][mask_visible] if feat != "index" else None) for feat in gen_features.keys()})
+        gen_features = awkward.Record(
+            {feat: (gen_features[feat][mask_visible] if feat != "index" else None) for feat in gen_features.keys()}
+        )
     else:
         gen_features = awkward.Record({feat: gen_features[feat][mask_visible] for feat in gen_features.keys()})
 
@@ -705,8 +717,12 @@ def assign_genparticles_to_obj_and_merge(gpdata):
         ).todense()
     )
 
-    gp_to_calohit = coo_matrix((gpdata.genparticle_to_hit[2], (gpdata.genparticle_to_hit[0], gpdata.genparticle_to_hit[1])), shape=(n_gp, n_hit))
-    calohit_to_cluster = coo_matrix((gpdata.hit_to_cluster[2], (gpdata.hit_to_cluster[0], gpdata.hit_to_cluster[1])), shape=(n_hit, n_cluster))
+    gp_to_calohit = coo_matrix(
+        (gpdata.genparticle_to_hit[2], (gpdata.genparticle_to_hit[0], gpdata.genparticle_to_hit[1])), shape=(n_gp, n_hit)
+    )
+    calohit_to_cluster = coo_matrix(
+        (gpdata.hit_to_cluster[2], (gpdata.hit_to_cluster[0], gpdata.hit_to_cluster[1])), shape=(n_hit, n_cluster)
+    )
 
     gp_to_cluster = np.array((gp_to_calohit * calohit_to_cluster).todense())
 
@@ -886,7 +902,9 @@ def get_reco_properties(dataset, prop_data, iev):
         raise Exception("--dataset provided is not supported. Only 'fcc' or 'clic' are supported atm.")
 
     reco_p4 = vector.awk(
-        awkward.zip({"mass": reco_arr["mass"], "x": reco_arr["momentum.x"], "y": reco_arr["momentum.y"], "z": reco_arr["momentum.z"]})
+        awkward.zip(
+            {"mass": reco_arr["mass"], "x": reco_arr["momentum.x"], "y": reco_arr["momentum.y"], "z": reco_arr["momentum.z"]}
+        )
     )
     reco_arr["pt"] = reco_p4.pt
     reco_arr["eta"] = reco_p4.eta
@@ -1061,22 +1079,17 @@ def process_one_file(fn, ofn, dataset):
                 "MCParticles.daughters_end",
                 "_MCParticles_daughters/_MCParticles_daughters.index",  # similar to "MCParticles#1.index" in clic
                 track_coll,
-                # "_SiTracks_trackStates",
                 "_SiTracks_Refitted_trackStates",
                 "PandoraClusters",
                 "_PandoraClusters_hits/_PandoraClusters_hits.index",
                 "_PandoraClusters_hits/_PandoraClusters_hits.collectionID",
                 "PandoraPFOs",
-                "SiTracks_Refitted_dQdx",  # TODO: new
+                "SiTracks_Refitted_dQdx",
             ]
         )
         calohit_links = arrs.arrays(
             [
                 "CalohitMCTruthLink.weight",
-                # "_CalohitMCTruthLink_rec/_CalohitMCTruthLink_rec.collectionID",
-                # "_CalohitMCTruthLink_rec/_CalohitMCTruthLink_rec.index",
-                # "_CalohitMCTruthLink_sim/_CalohitMCTruthLink_sim.collectionID",
-                # "_CalohitMCTruthLink_sim/_CalohitMCTruthLink_sim.index",
                 "_CalohitMCTruthLink_to/_CalohitMCTruthLink_to.collectionID",
                 "_CalohitMCTruthLink_to/_CalohitMCTruthLink_to.index",
                 "_CalohitMCTruthLink_from/_CalohitMCTruthLink_from.collectionID",
@@ -1086,10 +1099,6 @@ def process_one_file(fn, ofn, dataset):
         sitrack_links = arrs.arrays(
             [
                 "SiTracksMCTruthLink.weight",
-                # "_SiTracksMCTruthLink_rec/_SiTracksMCTruthLink_rec.collectionID",
-                # "_SiTracksMCTruthLink_rec/_SiTracksMCTruthLink_rec.index",
-                # "_SiTracksMCTruthLink_sim/_SiTracksMCTruthLink_sim.collectionID",
-                # "_SiTracksMCTruthLink_sim/_SiTracksMCTruthLink_sim.index",
                 "_SiTracksMCTruthLink_to/_SiTracksMCTruthLink_to.collectionID",
                 "_SiTracksMCTruthLink_to/_SiTracksMCTruthLink_to.index",
                 "_SiTracksMCTruthLink_from/_SiTracksMCTruthLink_from.collectionID",
@@ -1205,19 +1214,29 @@ def process_one_file(fn, ofn, dataset):
         assert np.all(used_rps == 1)
 
         gps_track = get_particle_feature_matrix(track_to_gp_all, gpdata_cleaned.gen_features, particle_feature_order)
-        gps_track[:, 0] = np.array([map_neutral_to_charged(map_pdgid_to_candid(p, c)) for p, c in zip(gps_track[:, 0], gps_track[:, 1])])
+        gps_track[:, 0] = np.array(
+            [map_neutral_to_charged(map_pdgid_to_candid(p, c)) for p, c in zip(gps_track[:, 0], gps_track[:, 1])]
+        )
         gps_cluster = get_particle_feature_matrix(cluster_to_gp_all, gpdata_cleaned.gen_features, particle_feature_order)
-        gps_cluster[:, 0] = np.array([map_charged_to_neutral(map_pdgid_to_candid(p, c)) for p, c in zip(gps_cluster[:, 0], gps_cluster[:, 1])])
+        gps_cluster[:, 0] = np.array(
+            [map_charged_to_neutral(map_pdgid_to_candid(p, c)) for p, c in zip(gps_cluster[:, 0], gps_cluster[:, 1])]
+        )
         gps_cluster[:, 1] = 0
 
         rps_track = get_particle_feature_matrix(track_to_rp_all, reco_features, particle_feature_order)
-        rps_track[:, 0] = np.array([map_neutral_to_charged(map_pdgid_to_candid(p, c)) for p, c in zip(rps_track[:, 0], rps_track[:, 1])])
+        rps_track[:, 0] = np.array(
+            [map_neutral_to_charged(map_pdgid_to_candid(p, c)) for p, c in zip(rps_track[:, 0], rps_track[:, 1])]
+        )
         rps_cluster = get_particle_feature_matrix(cluster_to_rp_all, reco_features, particle_feature_order)
-        rps_cluster[:, 0] = np.array([map_charged_to_neutral(map_pdgid_to_candid(p, c)) for p, c in zip(rps_cluster[:, 0], rps_cluster[:, 1])])
+        rps_cluster[:, 0] = np.array(
+            [map_charged_to_neutral(map_pdgid_to_candid(p, c)) for p, c in zip(rps_cluster[:, 0], rps_cluster[:, 1])]
+        )
         rps_cluster[:, 1] = 0
 
         # all initial gen/reco particle energy must be reconstructable
-        assert abs(np.sum(gps_track[:, 6]) + np.sum(gps_cluster[:, 6]) - np.sum(gpdata_cleaned.gen_features["energy"])) < 1e-2
+        assert (
+            abs(np.sum(gps_track[:, 6]) + np.sum(gps_cluster[:, 6]) - np.sum(gpdata_cleaned.gen_features["energy"])) < 1e-2
+        )
 
         assert abs(np.sum(rps_track[:, 6]) + np.sum(rps_cluster[:, 6]) - np.sum(reco_features["energy"])) < 1e-2
 
@@ -1264,7 +1283,9 @@ def process_one_file(fn, ofn, dataset):
         sorted_jet_idx = awkward.argsort(target_jets.pt, axis=-1, ascending=False).to_list()
         target_jets_indices = target_jets_indices.to_list()
         for jet_idx in sorted_jet_idx:
-            jet_constituents = [index_mapping[idx] for idx in target_jets_indices[jet_idx]]  # map back to constituent index *before* masking
+            jet_constituents = [
+                index_mapping[idx] for idx in target_jets_indices[jet_idx]
+            ]  # map back to constituent index *before* masking
             ytarget_constituents[jet_constituents] = jet_idx
         ytarget_track_constituents = ytarget_constituents[: len(ytarget_track)]
         ytarget_cluster_constituents = ytarget_constituents[len(ytarget_track) :]

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -631,6 +631,7 @@ def get_genparticles_and_adjacencies(dataset, prop_data, hit_data, calohit_links
     idx_all_masked = np.where(mask_visible)[0]
     genpart_idx_all_to_filtered = {idx_all: idx_filtered for idx_filtered, idx_all in enumerate(idx_all_masked)}
 
+    print("mask_visible", mask_visible)
     if mask_visible.sum() == 0:
         return None
     else:

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -631,7 +631,7 @@ def get_genparticles_and_adjacencies(dataset, prop_data, hit_data, calohit_links
     idx_all_masked = np.where(mask_visible)[0]
     genpart_idx_all_to_filtered = {idx_all: idx_filtered for idx_filtered, idx_all in enumerate(idx_all_masked)}
 
-    print("gen_features", gen_features.keys())
+    print("mask_visible", mask_visible)
     gen_features = awkward.Record({feat: gen_features[feat][mask_visible] for feat in gen_features.keys()})
 
     genparticle_to_hit = filter_adj(genparticle_to_hit, genpart_idx_all_to_filtered)

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -631,9 +631,11 @@ def get_genparticles_and_adjacencies(dataset, prop_data, hit_data, calohit_links
     idx_all_masked = np.where(mask_visible)[0]
     genpart_idx_all_to_filtered = {idx_all: idx_filtered for idx_filtered, idx_all in enumerate(idx_all_masked)}
 
-    if len(mask_visible) == 1:
-        mask_visible = mask_visible.reshape(-1, 1)
-        print(mask_visible.shape)
+    print("mask_visible", mask_visible)
+    for feat in gen_features.keys():
+        print("feat", gen_features[feat])
+        break
+    # if len(mask_visible) == 1:
 
     gen_features = awkward.Record({feat: gen_features[feat][mask_visible] for feat in gen_features.keys()})
 

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -635,10 +635,11 @@ def get_genparticles_and_adjacencies(dataset, prop_data, hit_data, calohit_links
         print("only one particle exists in the event, will skip the event.")
 
         for feat in gen_features.keys():
+            print("feat", feat)
             print("gen_features[feat]", gen_features[feat])
             print("mask_visible", mask_visible)
             print("try", gen_features[feat][mask_visible])
-            break
+            # break
 
         # return None
 

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -633,7 +633,7 @@ def get_genparticles_and_adjacencies(dataset, prop_data, hit_data, calohit_links
 
     print("mask_visible", mask_visible)
     for feat in gen_features.keys():
-        print("feat", gen_features[feat].shape)
+        print("feat", gen_features[feat].size)
         break
     # if len(mask_visible) == 1:
 

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -633,7 +633,7 @@ def get_genparticles_and_adjacencies(dataset, prop_data, hit_data, calohit_links
 
     print("mask_visible", mask_visible)
     for feat in gen_features.keys():
-        print("feat", gen_features[feat])
+        print("feat", gen_features[feat].shape)
         break
     # if len(mask_visible) == 1:
 

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -500,7 +500,7 @@ def track_to_features(dataset, prop_data, iev):
     track_arr = prop_data["SiTracks_Refitted_dQdx"][iev]
     ret["dEdx"] = track_arr["SiTracks_Refitted_dQdx.dQdx.value"]
     ret["dEdxError"] = track_arr["SiTracks_Refitted_dQdx.dQdx.error"]
-    ret["radiusOfInnermostHit"] = track_arr["SiTracks_Refitted.Nholes"]  # TODO: fix
+    ret["radiusOfInnermostHit"] = track_arr["SiTracks_Refitted.error"]  # TODO: fix
 
     n_tr = len(ret["type"])
 

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -493,11 +493,7 @@ def track_to_features(dataset, prop_data, iev):
     # feats_from_track = ["type", "chi2", "ndf", "dEdx", "dEdxError", "radiusOfInnermostHit"]
     # ret = {feat: track_arr[track_coll + "." + feat] for feat in feats_from_track}
 
-    track_arr = prop_data[[track_coll] + ["SiTracks_Refitted_dQdx"]][iev]
-    print("track_arr", track_arr)
-
-    track_arr = prop_data[track_coll][iev]
-    print("track_arr", track_arr)
+    track_arr = {**prop_data[track_coll][iev], **prop_data["SiTracks_Refitted_dQdx"][iev]}
 
     feats_from_track = ["type", "chi2", "ndf"]
     ret = {feat: track_arr[track_coll + "/" + track_coll + "." + feat] for feat in feats_from_track}

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -496,6 +496,7 @@ def track_to_features(dataset, prop_data, iev):
     track_arr = prop_data[[track_coll] + ["SiTracks_Refitted_dQdx"]][iev]
     feats_from_track = ["type", "chi2", "ndf"]
     ret = {feat: track_arr[track_coll + "." + feat] for feat in feats_from_track}
+    ret = {feat: track_arr[track_coll + "/" + track_coll + "." + feat] for feat in feats_from_track}
 
     ret["dEdx"] = track_arr["SiTracks_Refitted_dQdx/SiTracks_Refitted_dQdx.dQdx.value"]
     ret["dEdxError"] = track_arr["SiTracks_Refitted_dQdx/SiTracks_Refitted_dQdx.dQdx.error"]

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -631,11 +631,10 @@ def get_genparticles_and_adjacencies(dataset, prop_data, hit_data, calohit_links
     idx_all_masked = np.where(mask_visible)[0]
     genpart_idx_all_to_filtered = {idx_all: idx_filtered for idx_filtered, idx_all in enumerate(idx_all_masked)}
 
-    if np.array(mask_visible).sum() == 0:
-        print("hop")
-        return None
-    print(mask_visible.shape)
-    mask_visible = mask_visible.reshape(-1, 1)
+    if len(mask_visible) == 1:
+        mask_visible = mask_visible.reshape(-1, 1)
+        print(mask_visible.shape)
+
     gen_features = awkward.Record({feat: gen_features[feat][mask_visible] for feat in gen_features.keys()})
 
     genparticle_to_hit = filter_adj(genparticle_to_hit, genpart_idx_all_to_filtered)

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -631,14 +631,8 @@ def get_genparticles_and_adjacencies(dataset, prop_data, hit_data, calohit_links
     idx_all_masked = np.where(mask_visible)[0]
     genpart_idx_all_to_filtered = {idx_all: idx_filtered for idx_filtered, idx_all in enumerate(idx_all_masked)}
 
-    if np.array(mask_visible).sum() == 0:
-        return None
-
-    print("mask_visible", mask_visible)
-    for feat in gen_features.keys():
-        print("feat", gen_features[feat].to_numpy().shape, gen_features[feat].to_numpy())
-        break
     if len(np.array(mask_visible)) == 1:
+        print("only one 'visible' particle is found, will skip the event.")
         return None
 
     gen_features = awkward.Record({feat: gen_features[feat][mask_visible] for feat in gen_features.keys()})

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -504,34 +504,34 @@ def track_to_features(dataset, prop_data, iev):
         track_arr = prop_data["SiTracks_Refitted_dQdx"][iev]
         ret["dEdx"] = track_arr["SiTracks_Refitted_dQdx.dQdx.value"]
         ret["dEdxError"] = track_arr["SiTracks_Refitted_dQdx.dQdx.error"]
-        ret["radiusOfInnermostHit"] = track_arr["SiTracks_Refitted_dQdx.dQdx.error"]  # TODO: fix
+        # ret["radiusOfInnermostHit"] = track_arr["SiTracks_Refitted_dQdx.dQdx.error"]  # TODO: fix
 
-        # num_tracks = len(track_arr[track_coll + "." + "type"])
-        # innermost_radius = []
-        # for itrack in range(num_tracks):
+        num_tracks = len(track_arr[track_coll + "." + "type"])
+        innermost_radius = []
+        for itrack in range(num_tracks):
 
-        #     # select the track states corresponding to itrack
-        #     # pick the state AtFirstHit
-        #     # https://github.com/key4hep/EDM4hep/blob/fe5a54046a91a7e648d0b588960db7841aebc670/edm4hep.yaml#L220
+            # select the track states corresponding to itrack
+            # pick the state AtFirstHit
+            # https://github.com/key4hep/EDM4hep/blob/fe5a54046a91a7e648d0b588960db7841aebc670/edm4hep.yaml#L220
 
-        #     ibegin = prop_data["SiTracks_Refitted/SiTracks_Refitted.trackStates_begin"].array()[iev][itrack]
-        #     iend = prop_data["SiTracks_Refitted/SiTracks_Refitted.trackStates_end"].array()[iev][itrack]
+            ibegin = prop_data["SiTracks_Refitted/SiTracks_Refitted.trackStates_begin"].array()[iev][itrack]
+            iend = prop_data["SiTracks_Refitted/SiTracks_Refitted.trackStates_end"].array()[iev][itrack]
 
-        #     refX = prop_data["_SiTracks_Refitted_trackStates/_SiTracks_Refitted_trackStates.referencePoint.x"].array()[iev][
-        #         ibegin:iend
-        #     ]
-        #     refY = prop_data["_SiTracks_Refitted_trackStates/_SiTracks_Refitted_trackStates.referencePoint.y"].array()[iev][
-        #         ibegin:iend
-        #     ]
-        #     location = prop_data["_SiTracks_Refitted_trackStates/_SiTracks_Refitted_trackStates.location"].array()[iev][
-        #         ibegin:iend
-        #     ]
+            refX = prop_data["_SiTracks_Refitted_trackStates/_SiTracks_Refitted_trackStates.referencePoint.x"].array()[iev][
+                ibegin:iend
+            ]
+            refY = prop_data["_SiTracks_Refitted_trackStates/_SiTracks_Refitted_trackStates.referencePoint.y"].array()[iev][
+                ibegin:iend
+            ]
+            location = prop_data["_SiTracks_Refitted_trackStates/_SiTracks_Refitted_trackStates.location"].array()[iev][
+                ibegin:iend
+            ]
 
-        #     istate = np.argmax(location == 2)  # 2 refers to AtFirstHit
+            istate = np.argmax(location == 2)  # 2 refers to AtFirstHit
 
-        #     innermost_radius.append(math.sqrt(refX[istate] ** 2 + refY[istate] ** 2))
+            innermost_radius.append(math.sqrt(refX[istate] ** 2 + refY[istate] ** 2))
 
-        # ret["radiusOfInnermostHit"] = np.array(innermost_radius)
+        ret["radiusOfInnermostHit"] = np.array(innermost_radius)
 
     else:
         raise Exception("--dataset provided is not supported. Only 'fcc' or 'clic' are supported atm.")

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -636,7 +636,7 @@ def get_genparticles_and_adjacencies(dataset, prop_data, hit_data, calohit_links
 
     print("mask_visible", mask_visible)
     for feat in gen_features.keys():
-        print("feat", gen_features[feat].to_numpy().shape)
+        print("feat", gen_features[feat].to_numpy().shape, gen_features[feat].to_numpy())
         break
     # if len(mask_visible) == 1:
 

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -632,8 +632,15 @@ def get_genparticles_and_adjacencies(dataset, prop_data, hit_data, calohit_links
     genpart_idx_all_to_filtered = {idx_all: idx_filtered for idx_filtered, idx_all in enumerate(idx_all_masked)}
 
     if len(np.array(mask_visible)) == 1:
-        print("only one 'visible' particle is found, will skip the event.")
-        return None
+        print("only one particle exists in the event, will skip the event.")
+
+        for feat in gen_features.keys():
+            print("gen_features[feat]", gen_features[feat])
+            print("mask_visible", mask_visible)
+            print("try", gen_features[feat][mask_visible])
+            break
+
+        # return None
 
     gen_features = awkward.Record({feat: gen_features[feat][mask_visible] for feat in gen_features.keys()})
 

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -269,10 +269,10 @@ def get_calohit_matrix_and_genadj(dataset, hit_data, calohit_links, iev, collect
         # calohit_to_gen_calo_idx = calohit_links["_CalohitMCTruthLink_rec/_CalohitMCTruthLink_rec.index"][iev]
         # calohit_to_gen_gen_idx = calohit_links["_CalohitMCTruthLink_sim/_CalohitMCTruthLink_sim.index"][iev]
 
-        calohit_to_gen_calo_colid = calohit_links["_CalohitMCTruthLink_to/_CalohitMCTruthLink_to.collectionID"][iev]
-        calohit_to_gen_gen_colid = calohit_links["_CalohitMCTruthLink_from/_CalohitMCTruthLink_from.collectionID"][iev]
-        calohit_to_gen_calo_idx = calohit_links["_CalohitMCTruthLink_to/_CalohitMCTruthLink_to.index"][iev]
-        calohit_to_gen_gen_idx = calohit_links["_CalohitMCTruthLink_from/_CalohitMCTruthLink_from.index"][iev]        
+        calohit_to_gen_calo_colid = calohit_links["_CalohitMCTruthLink_from/_CalohitMCTruthLink_from.collectionID"][iev]
+        calohit_to_gen_gen_colid = calohit_links["_CalohitMCTruthLink_to/_CalohitMCTruthLink_to.collectionID"][iev]
+        calohit_to_gen_calo_idx = calohit_links["_CalohitMCTruthLink_from/_CalohitMCTruthLink_from.index"][iev]
+        calohit_to_gen_gen_idx = calohit_links["_CalohitMCTruthLink_to/_CalohitMCTruthLink_to.index"][iev]        
     else:
         raise Exception("--dataset provided is not supported. Only 'fcc' or 'clic' are supported atm.")
 

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -631,8 +631,8 @@ def get_genparticles_and_adjacencies(dataset, prop_data, hit_data, calohit_links
     idx_all_masked = np.where(mask_visible)[0]
     genpart_idx_all_to_filtered = {idx_all: idx_filtered for idx_filtered, idx_all in enumerate(idx_all_masked)}
 
-    print("mask_visible.sum()", np.array(mask_visible).sum())
     if np.array(mask_visible).sum() == 0:
+        print("hop")
         return None
 
     gen_features = awkward.Record({feat: gen_features[feat][mask_visible] for feat in gen_features.keys()})

--- a/mlpf/data/key4hep/postprocessing.py
+++ b/mlpf/data/key4hep/postprocessing.py
@@ -631,6 +631,9 @@ def get_genparticles_and_adjacencies(dataset, prop_data, hit_data, calohit_links
     idx_all_masked = np.where(mask_visible)[0]
     genpart_idx_all_to_filtered = {idx_all: idx_filtered for idx_filtered, idx_all in enumerate(idx_all_masked)}
 
+    if np.array(mask_visible).sum() == 0:
+        return None
+
     print("mask_visible", mask_visible)
     for feat in gen_features.keys():
         print("feat", gen_features[feat].to_numpy().shape)

--- a/mlpf/heptfds/cld_pf_edm4hep/ttbar.py
+++ b/mlpf/heptfds/cld_pf_edm4hep/ttbar.py
@@ -24,10 +24,11 @@ FIXME
 
 
 class CldEdmTtbarPf(tfds.core.GeneratorBasedBuilder):
-    VERSION = tfds.core.Version("2.3.0")
+    VERSION = tfds.core.Version("2.5.0")
     RELEASE_NOTES = {
         "2.0.0": "Initial release",
         "2.3.0": "Fix target/truth momentum, st=1 more inclusive: PR352",
+        "2.5.0": "Use 10 splits, skip 2.4.0 to unify with CMS datasets",
     }
     MANUAL_DOWNLOAD_INSTRUCTIONS = """
     For the raw input files in ROOT EDM4HEP format, please see the citation above.

--- a/mlpf/heptfds/cld_pf_edm4hep/ttbar.py
+++ b/mlpf/heptfds/cld_pf_edm4hep/ttbar.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import tensorflow as tf
 import tensorflow_datasets as tfds
 from utils_edm import (
+    NUM_SPLITS,
     X_FEATURES_CL,
     X_FEATURES_TRK,
     Y_FEATURES,

--- a/mlpf/heptfds/cld_pf_edm4hep/ttbar.py
+++ b/mlpf/heptfds/cld_pf_edm4hep/ttbar.py
@@ -35,6 +35,9 @@ class CldEdmTtbarPf(tfds.core.GeneratorBasedBuilder):
     rsync -r --progress lxplus.cern.ch:/eos/user/j/jpata/mlpf/cld_edm4hep/ ./
     """
 
+    # create configs 1 ... NUM_SPLITS + 1 that allow to parallelize the dataset building
+    BUILDER_CONFIGS = [tfds.core.BuilderConfig(name=str(group)) for group in range(1, NUM_SPLITS + 1)]
+
     def __init__(self, *args, **kwargs):
         kwargs["file_format"] = tfds.core.FileFormat.ARRAY_RECORD
         super(CldEdmTtbarPf, self).__init__(*args, **kwargs)

--- a/mlpf/heptfds/cld_pf_edm4hep/ttbar.py
+++ b/mlpf/heptfds/cld_pf_edm4hep/ttbar.py
@@ -76,7 +76,7 @@ class CldEdmTtbarPf(tfds.core.GeneratorBasedBuilder):
 
     def _split_generators(self, dl_manager: tfds.download.DownloadManager):
         path = dl_manager.manual_dir
-        return split_sample(Path(path / "p8_ee_tt_ecm365"))
+        return split_sample(Path(path / "p8_ee_tt_ecm365"), self.builder_config, num_splits=NUM_SPLITS)
 
     def _generate_examples(self, files):
         return generate_examples(files)

--- a/mlpf/heptfds/clic_pf_edm4hep/gamma.py
+++ b/mlpf/heptfds/clic_pf_edm4hep/gamma.py
@@ -1,0 +1,82 @@
+from pathlib import Path
+
+import tensorflow as tf
+import tensorflow_datasets as tfds
+from utils_edm import (
+    NUM_SPLITS,
+    X_FEATURES_CL,
+    X_FEATURES_TRK,
+    Y_FEATURES,
+    generate_examples,
+    split_sample,
+)
+
+_DESCRIPTION = """
+CLIC EDM4HEP dataset with single photon gun samples.
+  - X: reconstructed tracks and clusters, variable number N per event
+  - ygen: stable generator particles, zero-padded to N per event
+  - ycand: baseline particle flow particles, zero-padded to N per event
+"""
+
+_CITATION = """
+Pata, Joosep, Wulff, Eric, Duarte, Javier, Mokhtar, Farouk, Zhang, Mengke, Girone, Maria, & Southwick, David. (2023).
+Simulated datasets for detector and particle flow reconstruction: CLIC detector (1.1) [Data set].
+Zenodo. https://doi.org/10.5281/zenodo.8260741
+"""
+
+
+class ClicEdmGamma(tfds.core.GeneratorBasedBuilder):
+    VERSION = tfds.core.Version("2.5.0")
+    RELEASE_NOTES = {
+        "2.5.0": "Use 10 splits, skip 2.4.0 to unify with CMS datasets",
+    }
+    MANUAL_DOWNLOAD_INSTRUCTIONS = """
+    For the raw input files in ROOT EDM4HEP format, please see the citation above.
+
+    The processed tensorflow_dataset can also be downloaded from:
+    rsync -r --progress lxplus.cern.ch:/eos/user/j/jpata/mlpf/clic_edm4hep/ ./
+    """
+
+    # create configs 1 ... NUM_SPLITS + 1 that allow to parallelize the dataset building
+    BUILDER_CONFIGS = [tfds.core.BuilderConfig(name=str(group)) for group in range(1, NUM_SPLITS + 1)]
+
+    def __init__(self, *args, **kwargs):
+        kwargs["file_format"] = tfds.core.FileFormat.ARRAY_RECORD
+        super(ClicEdmGamma, self).__init__(*args, **kwargs)
+
+    def _info(self) -> tfds.core.DatasetInfo:
+        """Returns the dataset metadata."""
+        return tfds.core.DatasetInfo(
+            builder=self,
+            description=_DESCRIPTION,
+            features=tfds.features.FeaturesDict(
+                {
+                    "X": tfds.features.Tensor(
+                        shape=(
+                            None,
+                            max(len(X_FEATURES_TRK), len(X_FEATURES_CL)),
+                        ),
+                        dtype=tf.float32,
+                    ),
+                    "ytarget": tfds.features.Tensor(shape=(None, len(Y_FEATURES)), dtype=tf.float32),
+                    "ycand": tfds.features.Tensor(shape=(None, len(Y_FEATURES)), dtype=tf.float32),
+                    "genmet": tfds.features.Scalar(dtype=tf.float32),
+                    "genjets": tfds.features.Tensor(shape=(None, 4), dtype=tf.float32),
+                    "targetjets": tfds.features.Tensor(shape=(None, 4), dtype=tf.float32),
+                }
+            ),
+            homepage="https://github.com/jpata/particleflow",
+            citation=_CITATION,
+            metadata=tfds.core.MetadataDict(
+                x_features_track=X_FEATURES_TRK,
+                x_features_cluster=X_FEATURES_CL,
+                y_features=Y_FEATURES,
+            ),
+        )
+
+    def _split_generators(self, dl_manager: tfds.download.DownloadManager):
+        path = dl_manager.manual_dir
+        return split_sample(Path(path / "gamma//"), self.builder_config, num_splits=NUM_SPLITS)
+
+    def _generate_examples(self, files):
+        return generate_examples(files)

--- a/mlpf/model/PFDataset.py
+++ b/mlpf/model/PFDataset.py
@@ -228,6 +228,7 @@ def get_interleaved_dataloaders(world_size, rank, config, use_cuda, use_ray):
                 split_configs = config[f"{split}_dataset"][config["dataset"]][type_]["samples"][sample]["splits"]
                 print("split_configs", split_configs)
 
+                nevents = None
                 if not (config[f"n{split}"] is None):
                     nevents = config[f"n{split}"] // len(split_configs)
 

--- a/mlpf/model/PFDataset.py
+++ b/mlpf/model/PFDataset.py
@@ -116,9 +116,7 @@ class PFDataset:
             builder = tfds.builder(name, data_dir=data_dir)
         except Exception:
             _logger.error(
-                "Could not find dataset {} in {}, please check that you have downloaded the correct version of the dataset".format(
-                    name, data_dir
-                )
+                "Could not find dataset {} in {}, please check that you have downloaded the correct version of the dataset".format(name, data_dir)
             )
             sys.exit(1)
         self.ds = TFDSDataSource(builder.as_data_source(split=split), sort=sort)
@@ -157,9 +155,7 @@ class PFBatch:
 class Collater:
     def __init__(self, per_particle_keys_to_get, per_event_keys_to_get, **kwargs):
         super(Collater, self).__init__(**kwargs)
-        self.per_particle_keys_to_get = (
-            per_particle_keys_to_get  # these quantities are a variable-length tensor per each event
-        )
+        self.per_particle_keys_to_get = per_particle_keys_to_get  # these quantities are a variable-length tensor per each event
         self.per_event_keys_to_get = per_event_keys_to_get  # these quantities are one value (scalar) per event
 
     def __call__(self, inputs):
@@ -167,9 +163,7 @@ class Collater:
 
         # per-particle quantities need to be padded across events of different size
         for key_to_get in self.per_particle_keys_to_get:
-            ret[key_to_get] = torch.nn.utils.rnn.pad_sequence(
-                [torch.tensor(inp[key_to_get]).to(torch.float32) for inp in inputs], batch_first=True
-            )
+            ret[key_to_get] = torch.nn.utils.rnn.pad_sequence([torch.tensor(inp[key_to_get]).to(torch.float32) for inp in inputs], batch_first=True)
 
         # per-event quantities can be stacked across events
         for key_to_get in self.per_event_keys_to_get:
@@ -266,9 +260,7 @@ def get_interleaved_dataloaders(world_size, rank, config, use_cuda, use_ray):
             loader = torch.utils.data.DataLoader(
                 dataset,
                 batch_size=batch_size,
-                collate_fn=Collater(
-                    ["X", "ytarget", "ytarget_pt_orig", "ytarget_e_orig", "genjets", "targetjets"], ["genmet"]
-                ),
+                collate_fn=Collater(["X", "ytarget", "ytarget_pt_orig", "ytarget_e_orig", "genjets", "targetjets"], ["genmet"]),
                 sampler=sampler,
                 num_workers=config["num_workers"],
                 prefetch_factor=config["prefetch_factor"],


### PR DESCRIPTION
Addressing issue https://github.com/jpata/particleflow/issues/333
(Also fixes minor bug regarding the tfds dataset splitting for pipelines where `ntrain`/`nvalid` are given.)

**Changes**
- Wrote a new `postprocessing.py` script to unify the postprocessing of events generated with key4hep under the EDM4HEP format
- The new script can be run with the following choices for `--dataset [clic, fcc]`

The following commands were tested:

**For FCCee dataset postprocessing**
`python mlpf/data/key4hep/postprocessing.py --input /pfvolcentral/data/cld_key4hep/2024_05_full/p8_ee_tt_ecm365/root/reco_p8_ee_tt_ecm365_100038.root --outpath /pfvolcentral/data/cld_key4hep/2024_05_full/p8_ee_tt_ecm365/raw/p8_ee_tt_ecm365/ --dataset fcc`

`tfds build mlpf/heptfds/cld_pf_edm4hep/ttbar --manual_dir /pfvolcentral/data/cld_key4hep/2024_05_full/p8_ee_tt_ecm365/raw/`

**For CLIC dataset postprocessing**
`python mlpf/data/key4hep/postprocessing.py --input /pfvolcentral/data/clic_key4hep/2024_07/gamma/root/ --outpath /pfvolcentral/data/clic_key4hep/2024_07/gamma/raw/gamma/ --dataset clic`


**References:**
Breaking changes that have been introduced in EDM4hep v1.0
- [key4hep/EDM4hep#326](https://github.com/key4hep/EDM4hep/pull/326): the variable `radiusOfInnermostHit` was removed (the current PR creates the variable manually and was validated using the old files that had this branch present.)
- [key4hep/EDM4hep#341](https://github.com/key4hep/EDM4hep/pull/341): the associations to links were renamed. CaloHitLinks have been renamed as follows `reco->from` and `sim->to`
- [key4hep/EDM4hep#311](https://github.com/key4hep/EDM4hep/pull/311): the dEdx variable has been renamed to dQ/dx and moved under different collection (from `SiTracks_Refitted` to `SiTracks_Refitted_dQdx`)

The full list of all breaking changes is listed here: [key4hep/EDM4hep#261](https://github.com/key4hep/EDM4hep/pull/261)