### PR TITLE
allow missing layers in models when loading checkpoint

### DIFF
--- a/mlpf/model/training.py
+++ b/mlpf/model/training.py
@@ -912,16 +912,34 @@ def run(rank, world_size, config, args, outdir, logfile):
         checkpoint = torch.load(config["load"], map_location=torch.device(rank))
         start_epoch = checkpoint["extra_state"]["epoch"] + 1
 
+        missing_keys, strict = [], True
         for k in model.state_dict().keys():
             shp0 = model.state_dict()[k].shape
-            shp1 = checkpoint["model_state_dict"][k].shape
+            try:
+                shp1 = checkpoint["model_state_dict"][k].shape
+            except KeyError as e:
+                missing_keys.append(k)
+                continue
             if shp0 != shp1:
                 raise Exception("shape mismatch in {}, {}!={}".format(k, shp0, shp1))
 
+        if len(missing_keys) > 0:
+            _logger.warning(f"The following keys are missing in the checkpoint file {missing_keys}", color="red")
+            while True:
+                prompt = input("Do you want to try loading the model checkpoint with relaxed constraints? [y/n]")
+                if prompt == "n":
+                    raise KeyError
+                elif prompt == "y":
+                    _logger.warning(f"Optimizer checkpoint will not be loaded", color="bold")
+                    strict = False
+                    break
+
         if (rank == 0) or (rank == "cpu"):
             _logger.info("Loaded model weights from {}".format(config["load"]), color="bold")
-
-        model, optimizer = load_checkpoint(checkpoint, model, optimizer)
+        if strict:
+            model, optimizer = load_checkpoint(checkpoint, model, optimizer, strict)
+        else:
+            model = load_checkpoint(checkpoint, model, None, strict)
     else:  # instantiate a new model in the outdir created
         model_kwargs = {
             "input_dim": len(X_FEATURES[config["dataset"]]),

--- a/mlpf/model/utils.py
+++ b/mlpf/model/utils.py
@@ -257,14 +257,14 @@ def print_optimizer_stats(optimizer, stage):
                     print(f"    {key}: {value}")
 
 
-def load_checkpoint(checkpoint, model, optimizer=None):
+def load_checkpoint(checkpoint, model, optimizer=None, strict=True):
     if optimizer:
         print_optimizer_stats(optimizer, "Before loading")
 
     if isinstance(model, torch.nn.parallel.DistributedDataParallel):
-        model.module.load_state_dict(checkpoint["model_state_dict"])
+        model.module.load_state_dict(checkpoint["model_state_dict"], strict=strict)
     else:
-        model.load_state_dict(checkpoint["model_state_dict"])
+        model.load_state_dict(checkpoint["model_state_dict"], strict=strict)
 
     if optimizer:
         optimizer.load_state_dict(checkpoint["optimizer_state_dict"])


### PR DESCRIPTION
This PR allows users to load checkpoints with missing layers compared to the model defined so one can load pre-trained weight when adding more layers to the model. 

However, optimizer checkpoint is not handled yet because I imagine we most likely will freeze the pre-trained weight and just train on whatever new layers we are adding. Of course, this feature can be extended to the optimizer checkpoint as well (with more work).