### PR TITLE
fix: multi-gpu hang

### DIFF
--- a/mlpf/model/inference.py
+++ b/mlpf/model/inference.py
@@ -150,7 +150,7 @@ def run_predictions(world_size, rank, model, loader, sample, outpath, jetdef, je
     if (world_size > 1) and (rank != 0):
         iterator = enumerate(loader)
     else:
-        iterator = tqdm.tqdm(enumerate(loader), total=len(loader))
+        iterator = tqdm.tqdm(enumerate(loader), total=len(loader), desc=f"Running predictions on sample {sample} on rank={rank}")
 
     ti = time.time()
     for i, batch in iterator:

--- a/mlpf/plotting/plot_utils.py
+++ b/mlpf/plotting/plot_utils.py
@@ -293,7 +293,7 @@ def load_eval_data(path, max_files=None):
     if max_files is not None:
         filelist = filelist[:max_files]
 
-    for fi in tqdm.tqdm(filelist):
+    for fi in tqdm.tqdm(filelist, desc="Loading eval data"):
         dd = awkward.from_parquet(fi)
         yvals.append(dd)
         filenames.append(fi)

--- a/scripts/flatiron/scan_variables.py
+++ b/scripts/flatiron/scan_variables.py
@@ -53,6 +53,19 @@ def replaceline_batch_multiplier(fname, bmultiplier):
     )
 
 
+def replaceline_num_gpus(fname, num_gpus):
+    replaceline_and_save(
+        fname,
+        findln="#SBATCH --gpus-per-node",
+        newline="#SBATCH --gpus-per-node={}".format(num_gpus),
+    )
+    replaceline_and_save(
+        fname,
+        findln="#SBATCH --gpus-per-task",
+        newline="#SBATCH --gpus-per-task={}".format(num_gpus),
+    )
+
+
 def replaceline_ntrain(fname, ntrain):
     replaceline_and_save(
         fname,
@@ -62,23 +75,46 @@ def replaceline_ntrain(fname, ntrain):
 
 
 # Configuration parameters
-batch_file = "/mnt/ceph/users/ewulff/particleflow/scripts/flatiron/pt_raytrain_h100.slurm"
-config_file = "/mnt/ceph/users/ewulff/particleflow/parameters/pytorch/pyg-cms.yaml"
-prefix_string = "BSscan_mlpf_bs{}_"
-bs_list = [4, 8, 12, 16, 24, 32]
-bs_list = [8]
+batch_file = "/mnt/ceph/users/ewulff/particleflow/scripts/flatiron/pt_raytrain_a100.slurm"
+
+# configuration file
+# config_file = "/mnt/ceph/users/ewulff/particleflow/parameters/pytorch/pyg-cms.yaml"
+config_file = "/mnt/ceph/users/ewulff/particleflow/parameters/pytorch/pyg-clic.yaml"
+
+# Batch size scan
+# prefix_string = "BSscan_mlpf_bs{}_"
+# bs_list = [4, 8, 12, 16, 24, 32]
+# bs_list = [32, 64, 128, 256]
+
+# Number of GPUs scan
+prefix_string = "GPUscan_mlpf_gpus{}_"
+num_gpus_list = [1, 2, 4]
 
 # Run the jobs
 processes = []
-for bs in bs_list:
-    replaceline_batch_multiplier(batch_file, bs)
+
+# BS scan
+# for bs in bs_list:
+#     replaceline_batch_multiplier(batch_file, bs)
+#     time.sleep(1)
+#     process = subprocess.run(
+#         ["sbatch", batch_file, config_file, prefix_string.format(bs)],
+#         stdout=subprocess.PIPE,
+#         universal_newlines=True,
+#     )
+#     processes.append(process)
+
+# GPU scan
+for num_gpus in num_gpus_list:
+    replaceline_num_gpus(batch_file, num_gpus)
     time.sleep(1)
     process = subprocess.run(
-        ["sbatch", batch_file, config_file, prefix_string.format(bs)],
+        ["sbatch", batch_file, config_file, prefix_string.format(num_gpus)],
         stdout=subprocess.PIPE,
         universal_newlines=True,
     )
     processes.append(process)
 
+# Print the submitted jobs
 for proc in processes:
     print(proc)


### PR DESCRIPTION
Addresses issue https://github.com/jpata/particleflow/issues/390.

When using more than 1 GPU a NCCL timeout error was raised at the end of the first epoch. The issue was not present if I commented out the entire if-block that runs the end-of-epoch tests, including calls to the `run_predictions()` and `make_plots()` functions.

Moving the call to `run_test()`, which contains the calls to `run_predictions()` and `make_plots()` to run on all GPUs instead of just rank 0 solved the issue.