### PR TITLE
remove confusing outdir option

### DIFF
--- a/mlpf/model/inference.py
+++ b/mlpf/model/inference.py
@@ -201,8 +201,17 @@ def make_plots(outpath, sample, dataset, dir_name="", ntest_files=-1):
         yvals,
         cp_dir=plots_path,
         bins=np.linspace(0.5, 1.5, 500),
-        logy=False,
+        logy=True,
         file_modifier="_bins_0p5_1p5",
+        dataset=dataset,
+        sample=sample,
+    )
+    plot_jet_ratio(
+        yvals,
+        cp_dir=plots_path,
+        bins=np.linspace(0, 2, 500),
+        logy=True,
+        file_modifier="_bins_0_2",
         dataset=dataset,
         sample=sample,
     )

--- a/mlpf/model/training.py
+++ b/mlpf/model/training.py
@@ -616,28 +616,8 @@ def run(rank, world_size, config, outdir, logfile):
     checkpoint_dir.mkdir(parents=True, exist_ok=True)
 
     if config["load"]:  # load a pre-trained model
-
-        if config["finetune"]:
-            # outdir is now the new directory for finetuning so must retrieve model_kwargs from the load dir
-            def get_relevant_directory(path):
-                # Get the parent directory of the given path
-                parent_dir = os.path.dirname(path)
-
-                # Get the parent of the parent directory
-                grandparent_dir = os.path.dirname(parent_dir)
-
-                # Check if the parent directory is "checkpoints"
-                if os.path.basename(parent_dir) == "checkpoints":
-                    return grandparent_dir
-                else:
-                    return parent_dir
-
-            with open(f"{get_relevant_directory(config['load'])}/model_kwargs.pkl", "rb") as f:
-                model_kwargs = pkl.load(f)
-
-        else:
-            with open(f"{outdir}/model_kwargs.pkl", "rb") as f:
-                model_kwargs = pkl.load(f)
+        with open(f"{outdir}/model_kwargs.pkl", "rb") as f:
+            model_kwargs = pkl.load(f)
 
         _logger.info("model_kwargs: {}".format(model_kwargs))
 

--- a/mlpf/model/training.py
+++ b/mlpf/model/training.py
@@ -635,6 +635,7 @@ def run(rank, world_size, config, outdir, logfile):
         optimizer = torch.optim.AdamW(model.parameters(), lr=config["lr"])
         checkpoint = torch.load(config["load"], map_location=torch.device(rank))
 
+        import pdb;pdb.set_trace()
         if config["start_epoch"] is None:
             start_epoch = int(os.path.basename(config["load"]).split("-")[1]) + 1
         else:
@@ -804,7 +805,10 @@ def override_config(config: dict, args):
     config["test"] = args.test
     config["make_plots"] = args.make_plots
 
-    config["start_epoch"] = int(args.start_epoch)
+    if not args.start_epoch is None:
+        args.start_epoch = int(args.start_epoch)
+    config["start_epoch"] = args.start_epoch
+
     if config["load"] is None:
         if config["start_epoch"] is None:
             config["start_epoch"] = 1

--- a/mlpf/model/training.py
+++ b/mlpf/model/training.py
@@ -647,7 +647,7 @@ def run(rank, world_size, config, outdir, logfile):
 
         if len(missing_keys) > 0:
             _logger.warning(f"The following parameters are missing in the checkpoint file {missing_keys}", color="red")
-            if config["relaxed_load"]:
+            if config.get("relaxed_load", True):
                 _logger.warning("Optimizer checkpoint will not be loaded", color="bold")
                 strict = False
             else:

--- a/mlpf/model/training.py
+++ b/mlpf/model/training.py
@@ -635,7 +635,6 @@ def run(rank, world_size, config, outdir, logfile):
         optimizer = torch.optim.AdamW(model.parameters(), lr=config["lr"])
         checkpoint = torch.load(config["load"], map_location=torch.device(rank))
 
-        import pdb;pdb.set_trace()
         if config["start_epoch"] is None:
             start_epoch = int(os.path.basename(config["load"]).split("-")[1]) + 1
         else:

--- a/mlpf/model/training.py
+++ b/mlpf/model/training.py
@@ -1,6 +1,5 @@
 import os
 import os.path as osp
-import pickle as pkl
 import time
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -628,7 +627,7 @@ def run(rank, world_size, config, outdir, logfile):
         "learned_representation_mode": config["model"]["learned_representation_mode"],
         **config["model"][config["conv_type"]],
     }
-    
+
     # load a pre-trained checkpoint (continue an aborted training or fine-tune)
     if config["load"]:
         model = MLPF(**model_kwargs).to(torch.device(rank))
@@ -665,7 +664,7 @@ def run(rank, world_size, config, outdir, logfile):
 
         model, optimizer = load_checkpoint(checkpoint, model, optimizer, strict)
 
-        #if we are rewinding the epoch counter to 1, then we also want to set the learning rate to the initial value
+        # if we are rewinding the epoch counter to 1, then we also want to set the learning rate to the initial value
         if start_epoch == 1:
             for g in optimizer.param_groups:
                 if g["lr"] != config["lr"]:
@@ -804,14 +803,13 @@ def override_config(config: dict, args):
     config["test"] = args.test
     config["make_plots"] = args.make_plots
 
-    if not args.start_epoch is None:
+    if args.start_epoch is not None:
         args.start_epoch = int(args.start_epoch)
     config["start_epoch"] = args.start_epoch
 
     if config["load"] is None:
         if config["start_epoch"] is None:
             config["start_epoch"] = 1
-        
 
     return config
 

--- a/mlpf/model/training.py
+++ b/mlpf/model/training.py
@@ -615,24 +615,30 @@ def run(rank, world_size, config, outdir, logfile):
     checkpoint_dir = Path(outdir) / "checkpoints"
     checkpoint_dir.mkdir(parents=True, exist_ok=True)
 
-    if config["load"]:  # load a pre-trained model
-        with open(f"{outdir}/model_kwargs.pkl", "rb") as f:
-            model_kwargs = pkl.load(f)
-
-        _logger.info("model_kwargs: {}".format(model_kwargs))
-
-        if config["conv_type"] == "attention":
-            model_kwargs["attention_type"] = config["model"]["attention"]["attention_type"]
-
+    model_kwargs = {
+        "input_dim": len(X_FEATURES[config["dataset"]]),
+        "num_classes": len(CLASS_LABELS[config["dataset"]]),
+        "input_encoding": config["model"]["input_encoding"],
+        "pt_mode": config["model"]["pt_mode"],
+        "eta_mode": config["model"]["eta_mode"],
+        "sin_phi_mode": config["model"]["sin_phi_mode"],
+        "cos_phi_mode": config["model"]["cos_phi_mode"],
+        "energy_mode": config["model"]["energy_mode"],
+        "elemtypes_nonzero": ELEM_TYPES_NONZERO[config["dataset"]],
+        "learned_representation_mode": config["model"]["learned_representation_mode"],
+        **config["model"][config["conv_type"]],
+    }
+    
+    # load a pre-trained checkpoint (continue an aborted training or fine-tune)
+    if config["load"]:
         model = MLPF(**model_kwargs).to(torch.device(rank))
         optimizer = torch.optim.AdamW(model.parameters(), lr=config["lr"])
-
         checkpoint = torch.load(config["load"], map_location=torch.device(rank))
 
-        if not config["finetune"]:  # for --finetune we want to start the count from scratch
-            # check if we reached the first epoch in the checkpoint
-            if "epoch" in checkpoint["extra_state"]:
-                start_epoch = checkpoint["extra_state"]["epoch"] + 1
+        if config["start_epoch"] is None:
+            start_epoch = int(os.path.basename(config["load"]).split("-")[1]) + 1
+        else:
+            start_epoch = config["start_epoch"]
 
         missing_keys, strict = [], True
         for k in model.state_dict().keys():
@@ -656,24 +662,17 @@ def run(rank, world_size, config, outdir, logfile):
 
         if (rank == 0) or (rank == "cpu"):
             _logger.info("Loaded model weights from {}".format(config["load"]), color="bold")
-        if strict:
-            model, optimizer = load_checkpoint(checkpoint, model, optimizer, strict)
-        else:
-            model = load_checkpoint(checkpoint, model, None, strict)
+
+        model, optimizer = load_checkpoint(checkpoint, model, optimizer, strict)
+
+        #if we are rewinding the epoch counter to 1, then we also want to set the learning rate to the initial value
+        if start_epoch == 1:
+            for g in optimizer.param_groups:
+                if g["lr"] != config["lr"]:
+                    _logger.info("optimizer param group lr changed {} -> {}".format(g["lr"], config["lr"]))
+                    g["lr"] = config["lr"]
+
     else:  # instantiate a new model in the outdir created
-        model_kwargs = {
-            "input_dim": len(X_FEATURES[config["dataset"]]),
-            "num_classes": len(CLASS_LABELS[config["dataset"]]),
-            "input_encoding": config["model"]["input_encoding"],
-            "pt_mode": config["model"]["pt_mode"],
-            "eta_mode": config["model"]["eta_mode"],
-            "sin_phi_mode": config["model"]["sin_phi_mode"],
-            "cos_phi_mode": config["model"]["cos_phi_mode"],
-            "energy_mode": config["model"]["energy_mode"],
-            "elemtypes_nonzero": ELEM_TYPES_NONZERO[config["dataset"]],
-            "learned_representation_mode": config["model"]["learned_representation_mode"],
-            **config["model"][config["conv_type"]],
-        }
         model = MLPF(**model_kwargs)
         optimizer = torch.optim.AdamW(model.parameters(), lr=config["lr"])
 
@@ -804,6 +803,12 @@ def override_config(config: dict, args):
     config["train"] = args.train
     config["test"] = args.test
     config["make_plots"] = args.make_plots
+
+    config["start_epoch"] = int(args.start_epoch)
+    if config["load"] is None:
+        if config["start_epoch"] is None:
+            config["start_epoch"] = 1
+        
 
     return config
 

--- a/mlpf/model/utils.py
+++ b/mlpf/model/utils.py
@@ -259,22 +259,19 @@ def print_optimizer_stats(optimizer, stage):
                     print(f"    {key}: {value}")
 
 
-def load_checkpoint(checkpoint, model, optimizer=None, strict=True):
-    if optimizer:
-        print_optimizer_stats(optimizer, "Before loading")
-
+def load_checkpoint(checkpoint, model, optimizer, strict=True):
     if isinstance(model, torch.nn.parallel.DistributedDataParallel):
         model.module.load_state_dict(checkpoint["model_state_dict"], strict=strict)
     else:
         model.load_state_dict(checkpoint["model_state_dict"], strict=strict)
 
-    if optimizer:
+    if strict:
+        print_optimizer_stats(optimizer, "Before loading optimizer state")
         optimizer.load_state_dict(checkpoint["optimizer_state_dict"])
         logging.info("Loaded optimizer state")
-        print_optimizer_stats(optimizer, "After loading")
-        return model, optimizer
-    else:
-        return model
+        print_optimizer_stats(optimizer, "After loading optimizer state")
+
+    return model, optimizer
 
 
 def save_checkpoint(checkpoint_path, model, optimizer=None, extra_state=None):

--- a/mlpf/pipeline.py
+++ b/mlpf/pipeline.py
@@ -44,6 +44,7 @@ parser.add_argument(
 parser.add_argument("--train", action="store_true", default=None, help="initiates a training")
 parser.add_argument("--test", action="store_true", default=None, help="tests the model")
 parser.add_argument("--num-epochs", type=int, default=None, help="number of training epochs")
+parser.add_argument("--start-epoch", type=None, default=None, help="the initial epoch counter for LR decay and logging")
 parser.add_argument("--patience", type=int, default=None, help="patience before early stopping")
 parser.add_argument("--lr", type=float, default=None, help="learning rate")
 parser.add_argument(

--- a/mlpf/pipeline.py
+++ b/mlpf/pipeline.py
@@ -24,7 +24,9 @@ parser = argparse.ArgumentParser()
 
 # add default=None to all arparse arguments to ensure they do not override
 # values loaded from the config file given by --config unless explicitly given
-parser.add_argument("--experiment-dir", type=str, default=None, help="The directory where to save the weights and configs. if None, create a new one.")
+parser.add_argument(
+    "--experiment-dir", type=str, default=None, help="The directory where to save the weights and configs. if None, create a new one."
+)
 parser.add_argument("--config", type=str, default=None, help="yaml config")
 parser.add_argument("--prefix", type=str, default=None, help="prefix prepended to the experiment dir name")
 parser.add_argument("--data-dir", type=str, default=None, help="path to `tensorflow_datasets/`")
@@ -80,7 +82,7 @@ parser.add_argument(
 )
 parser.add_argument("--test-datasets", nargs="+", default=[], help="test samples to process")
 
-#options only used for the ray-based training
+# options only used for the ray-based training
 parser.add_argument("--ray-train", action="store_true", help="run training using Ray Train")
 parser.add_argument("--ray-local", action="store_true", default=None, help="run ray-train locally")
 parser.add_argument("--ray-cpus", type=int, default=None, help="CPUs for ray-train")

--- a/mlpf/plotting/plot_utils.py
+++ b/mlpf/plotting/plot_utils.py
@@ -80,6 +80,7 @@ CLASS_NAMES_CLIC = [
 CLASS_LABELS = {
     "cms": CLASS_LABELS_CMS,
     "clic": CLASS_LABELS_CLIC,
+    "cld": CLASS_LABELS_CLIC,
 }
 
 labels = {
@@ -138,6 +139,12 @@ EVALUATION_DATASET_NAMES = {
     "cms_pf_single_tau": r"single tau particle gun events",
     "cms_pf_single_k0": r"single K0 particle gun events",
     "cms_pf_sms_t1tttt": r"sms t1tttt events",
+}
+
+GENJET_BINS_PT_DATASET = {
+    "clic": [10, 20, 40, 60, 80, 100, 200],
+    "cld": [10, 20, 40, 60, 80, 100, 200],
+    "cms": [10, 20, 40, 60, 80, 100, 200, 400, 800],
 }
 
 
@@ -660,19 +667,19 @@ def plot_jet_ratio(
         label="MLPF $({:.2f}\pm{:.2f})$".format(p[0], p[1]),
     )
 
-    p = med_iqr(yvals["jet_ratio_gen_to_pred_nopu_pt"])
-    ret_dict["jet_ratio_gen_to_pred_nopu_pt"] = {
-        "med": p[0],
-        "iqr": p[1],
-        "match_frac": awkward.count(yvals["jet_ratio_gen_to_pred_nopu_pt"]) / awkward.count(yvals["jets_gen_pt"]),
-    }
-    plt.hist(
-        yvals["jet_ratio_gen_to_pred_nopu_pt"],
-        bins=bins,
-        histtype="step",
-        lw=2,
-        label="MLPF, no PU $({:.2f}\pm{:.2f})$".format(p[0], p[1]),
-    )
+    # p = med_iqr(yvals["jet_ratio_gen_to_pred_nopu_pt"])
+    # ret_dict["jet_ratio_gen_to_pred_nopu_pt"] = {
+    #     "med": p[0],
+    #     "iqr": p[1],
+    #     "match_frac": awkward.count(yvals["jet_ratio_gen_to_pred_nopu_pt"]) / awkward.count(yvals["jets_gen_pt"]),
+    # }
+    # plt.hist(
+    #     yvals["jet_ratio_gen_to_pred_nopu_pt"],
+    #     bins=bins,
+    #     histtype="step",
+    #     lw=2,
+    #     label="MLPF, no PU $({:.2f}\pm{:.2f})$".format(p[0], p[1]),
+    # )
 
     plt.xlabel(labels["reco_gen_jet_ratio"])
     plt.ylabel("Matched jets / bin")
@@ -1520,7 +1527,7 @@ def plot_jet_response_binned_vstarget(yvals, epoch=None, cp_dir=None, comet_expe
     pf_response = yvals["jet_ratio_target_to_cand_pt"]
     mlpf_response = yvals["jet_ratio_target_to_pred_pt"]
 
-    genjet_bins = [10, 20, 40, 60, 80, 100, 200, 400, 800]
+    genjet_bins = GENJET_BINS_PT_DATASET[dataset]
 
     x_vals = []
     pf_vals = []
@@ -1630,7 +1637,7 @@ def plot_jet_response_binned(yvals, epoch=None, cp_dir=None, comet_experiment=No
     pf_response = yvals["jet_ratio_gen_to_cand_pt"]
     mlpf_response = yvals["jet_ratio_gen_to_pred_pt"]
 
-    genjet_bins = [10, 20, 40, 60, 80, 100, 200, 400, 800]
+    genjet_bins = GENJET_BINS_PT_DATASET[dataset]
 
     x_vals = []
     target_vals = []
@@ -1713,6 +1720,7 @@ def plot_jet_response_binned(yvals, epoch=None, cp_dir=None, comet_experiment=No
     plt.ylabel("Response median")
     plt.xlabel(labels["gen_jet"])
     plt.tight_layout()
+    plt.ylim(0.9, 1.1)
     plt.axhline(1.0, color="black", ls="--", lw=0.5)
 
     EXPERIMENT_LABELS[dataset](ax)

--- a/parameters/pytorch/pyg-cld.yaml
+++ b/parameters/pytorch/pyg-cld.yaml
@@ -3,7 +3,7 @@ test: yes
 make_plots: yes
 comet: yes
 save_attention: yes
-dataset: clic
+dataset: cld
 sort_data: no
 data_dir:
 gpus: 1
@@ -105,7 +105,7 @@ raytune:
     n_random_steps: 10
 
 train_dataset:
-  clic:
+  cld:
     physical:
       batch_size: 1
       samples:
@@ -114,7 +114,7 @@ train_dataset:
           splits: [1,2,3,4,5,6,7,8,9,10]
 
 valid_dataset:
-  clic:
+  cld:
     physical:
       batch_size: 1
       samples:

--- a/parameters/pytorch/pyg-cld.yaml
+++ b/parameters/pytorch/pyg-cld.yaml
@@ -24,7 +24,7 @@ checkpoint_freq:
 comet_name: particleflow-pt
 comet_offline: False
 comet_step_freq: 100
-dtype: float32
+dtype: bfloat16
 val_freq:  # run an extra validation run every val_freq training steps
 
 model:
@@ -39,9 +39,9 @@ model:
 
   gnn_lsh:
     conv_type: gnn_lsh
-    embedding_dim: 512
-    width: 512
-    num_convs: 8
+    embedding_dim: 1024
+    width: 1024
+    num_convs: 3
     activation: "elu"
     # gnn-lsh specific parameters
     bin_size: 32
@@ -63,7 +63,7 @@ model:
     activation: "relu"
     head_dim: 32
     num_heads: 32
-    attention_type: math
+    attention_type: flash
     use_pre_layernorm: True
 
   mamba:

--- a/scripts/local_test_torch.sh
+++ b/scripts/local_test_torch.sh
@@ -36,11 +36,19 @@ python mlpf/pipeline.py --config parameters/pytorch/pyg-cms.yaml --data-dir ./te
   --prefix MLPF_test_ --num-epochs 2 --nvalid 1 --gpus 0 --train --test --make-plots --conv-type attention \
   --pipeline --dtype float32 --attention-type math --num-convs 1
 
-#continue training from previous epoch, save to the same experiment dir
+#continue training from previous epoch, save to the same experiment dir (resume training)
 python mlpf/pipeline.py --config parameters/pytorch/pyg-cms.yaml --data-dir ./tensorflow_datasets/ \
   --prefix MLPF_test_ --num-epochs 3 --nvalid 1 --gpus 0 --train --test --make-plots --conv-type attention \
   --pipeline --dtype float32 --attention-type math --num-convs 1 --load ${PWD}/experiments/MLPF_test_*/checkpoints/checkpoint-02-*.pth \
   --experiment-dir ${PWD}/experiments/MLPF_test_*
+
+#continue training from previous epoch, save to a new experiment dir (fine-tuning)
+python mlpf/pipeline.py --config parameters/pytorch/pyg-cms.yaml --data-dir ./tensorflow_datasets/ \
+  --prefix MLPF_test_ --num-epochs 3 --nvalid 1 --gpus 0 --train --test --make-plots --conv-type attention \
+  --pipeline --dtype float32 --attention-type math --num-convs 1 --load ${PWD}/experiments/MLPF_test_*/checkpoints/checkpoint-02-*.pth \
+  --start-epoch 1
+
+ls -lrt experiments/*/checkpoints/*
 
 # test Ray Train training
 python mlpf/pipeline.py --config parameters/pytorch/pyg-cms.yaml --data-dir ${PWD}/tensorflow_datasets/ \

--- a/scripts/local_test_torch.sh
+++ b/scripts/local_test_torch.sh
@@ -39,8 +39,8 @@ python mlpf/pipeline.py --config parameters/pytorch/pyg-cms.yaml --data-dir ./te
 #continue training from previous epoch, save to the same experiment dir
 python mlpf/pipeline.py --config parameters/pytorch/pyg-cms.yaml --data-dir ./tensorflow_datasets/ \
   --prefix MLPF_test_ --num-epochs 3 --nvalid 1 --gpus 0 --train --test --make-plots --conv-type attention \
-  --pipeline --dtype float32 --attention-type math --num-convs 1 --load ${PWD}/experiments/pyg*/checkpoints/checkpoint-02-*.pth \
-  --experiment-dir ${PWD}/experiments/pyg*
+  --pipeline --dtype float32 --attention-type math --num-convs 1 --load ${PWD}/experiments/MLPF_test_*/checkpoints/checkpoint-02-*.pth \
+  --experiment-dir ${PWD}/experiments/MLPF_test_*
 
 # test Ray Train training
 python mlpf/pipeline.py --config parameters/pytorch/pyg-cms.yaml --data-dir ${PWD}/tensorflow_datasets/ \

--- a/scripts/local_test_torch.sh
+++ b/scripts/local_test_torch.sh
@@ -36,6 +36,12 @@ python mlpf/pipeline.py --config parameters/pytorch/pyg-cms.yaml --data-dir ./te
   --prefix MLPF_test_ --num-epochs 2 --nvalid 1 --gpus 0 --train --test --make-plots --conv-type attention \
   --pipeline --dtype float32 --attention-type math --num-convs 1
 
+#continue training from previous epoch, save to the same experiment dir
+python mlpf/pipeline.py --config parameters/pytorch/pyg-cms.yaml --data-dir ./tensorflow_datasets/ \
+  --prefix MLPF_test_ --num-epochs 3 --nvalid 1 --gpus 0 --train --test --make-plots --conv-type attention \
+  --pipeline --dtype float32 --attention-type math --num-convs 1 --load ${PWD}/experiments/pyg*/checkpoints/checkpoint-02-*.pth \
+  --experiment-dir ${PWD}/experiments/pyg*
+
 # test Ray Train training
 python mlpf/pipeline.py --config parameters/pytorch/pyg-cms.yaml --data-dir ${PWD}/tensorflow_datasets/ \
 	--prefix MLPF_test_ --num-epochs 2 --nvalid 1 --gpus 0 --train --ray-train --ray-cpus 2 --ray-local --conv-type attention \

--- a/scripts/tallinn/a100-mig/pytorch-small-eval-clic.sh
+++ b/scripts/tallinn/a100-mig/pytorch-small-eval-clic.sh
@@ -13,4 +13,4 @@ singularity exec -B /scratch/persistent --nv \
      --env KERAS_BACKEND=torch \
      $IMG  python3 mlpf/pipeline.py --gpus 1 \
      --data-dir /scratch/persistent/joosep/tensorflow_datasets --config parameters/pytorch/pyg-clic.yaml \
-     --test --make-plots --gpu-batch-multiplier 100 --load $WEIGHTS --dtype bfloat16 --num-workers 0 --ntest 20000
+     --test --make-plots --gpu-batch-multiplier 100 --load $WEIGHTS --dtype bfloat16 --num-workers 0

--- a/scripts/tallinn/a100-mig/pytorch-small-eval-clic.sh
+++ b/scripts/tallinn/a100-mig/pytorch-small-eval-clic.sh
@@ -7,10 +7,11 @@
 IMG=/home/software/singularity/pytorch.simg:2024-12-03
 cd ~/particleflow
 
-WEIGHTS=experiments/pyg-clic_20250130_214007_333962/checkpoints/checkpoint-10-1.932789.pth
+WEIGHTS=experiments/pyg-clic_20250106_193536_269746/checkpoints/checkpoint-05-1.995116.pth
+_EXPDIR=experiments/pyg-clic_20250106_193536_269746
 singularity exec -B /scratch/persistent --nv \
      --env PYTHONPATH=`pwd` \
      --env KERAS_BACKEND=torch \
-     $IMG  python3 mlpf/pipeline.py --gpus 1 \
+     $IMG  python3 mlpf/pipeline.py --gpus 0 \
      --data-dir /scratch/persistent/joosep/tensorflow_datasets --config parameters/pytorch/pyg-clic.yaml \
-     --test --make-plots --gpu-batch-multiplier 100 --load $WEIGHTS --dtype bfloat16 --num-workers 0
+     --make-plots --gpu-batch-multiplier 100 --load $WEIGHTS --dtype bfloat16 --num-workers 0 --experiment-dir $_EXPDIR


### PR DESCRIPTION
- the only supported way to load pretrained weights for evaluation, fine-tuning or continuing a training is `--load`, removing `--fine-tune` and `--resume-training`.
- remove the automatic outdir guessing that was error-prone
- the `--experiment-dir` must be provided manually, or a new directory will be created under `experiments/...`