### PR TITLE
PyPI publishing workflow

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -3,7 +3,8 @@ name: Publish Python 🐍 distribution 📦 to PyPI and TestPyPI
 on:
   push:
     tags:
-      - 'test_v*'
+      - 'test_*'
+      - 'v*'
 
 jobs:
   build:
@@ -36,6 +37,7 @@ jobs:
     name: Publish Python 🐍 distribution 📦 to TestPyPI
     needs:
     - build
+    if: startsWith(github.ref, 'refs/tags/test_')
     runs-on: ubuntu-latest
 
     environment:
@@ -55,3 +57,26 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         repository-url: https://test.pypi.org/legacy/
+
+  publish-to-pypi:
+    name: Publish Python 🐍 distribution 📦 to PyPI
+    needs:
+    - build
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/particleflow
+
+    permissions:
+      id-token: write
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v6
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,6 +1,9 @@
 name: Publish Python 🐍 distribution 📦 to PyPI and TestPyPI
 
-on: push
+on:
+  push:
+    tags:
+      - 'test_v*'
 
 jobs:
   build:

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,33 +1,54 @@
-#from https://github.com/fastmachinelearning/hls4ml/blob/main/.github/workflows/pypi-publish.yml
-#Apache License 2.0, Fast Machine Learning Collective
-name: 📦 Packaging release to PyPI
-on:
-  workflow_dispatch:
-  pull_request:
-    branches: [main]
-  release:
-    types: [published]
+name: Publish Python 🐍 distribution 📦 to PyPI and TestPyPI
+
+on: push
 
 jobs:
-  release:
-    name: Upload new release to PyPI
+  build:
+    name: Build distribution 📦
     runs-on: ubuntu-latest
+
     steps:
-    - name: Checkout source
-      uses: actions/checkout@v6
+    - uses: actions/checkout@v6
       with:
-        submodules: recursive
-        fetch-depth: 0
-
-    - name: Build SDist and Wheel
-      run: pipx run build --sdist --wheel
-
-    - uses: actions/upload-artifact@v7
+        persist-credentials: false
+    - name: Set up Python
+      uses: actions/setup-python@v6
       with:
-        path: dist/*.*
+        python-version: "3.x"
+    - name: Install pypa/build
+      run: >-
+        python3 -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: python3 -m build
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v5
+      with:
+        name: python-package-distributions
+        path: dist/
 
-    - name: Publish 📦 to PyPI
-      if: startsWith(github.ref, 'refs/tags')
+  publish-to-testpypi:
+    name: Publish Python 🐍 distribution 📦 to TestPyPI
+    needs:
+    - build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/particleflow
+
+    permissions:
+      id-token: write
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v6
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution 📦 to TestPyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        password: ${{ secrets.PYPI_PASSWORD }}
+        repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,33 @@
+#from https://github.com/fastmachinelearning/hls4ml/blob/main/.github/workflows/pypi-publish.yml
+#Apache License 2.0, Fast Machine Learning Collective
+name: 📦 Packaging release to PyPI
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+  release:
+    types: [published]
+
+jobs:
+  release:
+    name: Upload new release to PyPI
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout source
+      uses: actions/checkout@v6
+      with:
+        submodules: recursive
+        fetch-depth: 0
+
+    - name: Build SDist and Wheel
+      run: pipx run build --sdist --wheel
+
+    - uses: actions/upload-artifact@v7
+      with:
+        path: dist/*.*
+
+    - name: Publish 📦 to PyPI
+      if: startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+### **Summary**
+
+**ML-based particle flow (MLPF)** focuses on developing full event reconstruction for particle detectors using computationally scalable and flexible machine learning models. The project aims to improve particle flow reconstruction across various detector environments, including CMS, as well as future detectors via Key4HEP.
+We build on existing, open-source simulation software by the experimental collaborations.
+
+<p float="left">
+  <img src="images/diagram.svg" alt="High-level overview" width="800"/>
+</p>
+
+---
+
 ### **TLDR; I just want to run the code**
 You can use `uv` to set up the repo and test that everything works:
 ```
@@ -13,16 +24,6 @@ apptainer exec --nv https://jpata.web.cern.ch/jpata/pytorch-20260305-08d6950.sif
 apptainer exec --nv https://jpata.web.cern.ch/jpata/pytorch-20260305-08d6950.sif ./scripts/local_test_cms.sh
 ```
 
-### **Summary**
-
-**ML-based particle flow (MLPF)** focuses on developing full event reconstruction for particle detectors using computationally scalable and flexible machine learning models. The project aims to improve particle flow reconstruction across various detector environments, including CMS, as well as future detectors via Key4HEP.
-We build on existing, open-source simulation software by the experimental collaborations.
-
-<p float="left">
-  <img src="images/diagram.svg" alt="High-level overview" width="800"/>
-</p>
-
----
 
 
 ### **Datasets**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "particleflow"
-version = "3.0.0"
+version = "3.1.0"
 authors = [
   { name = "Joosep Pata", email = "joosep.pata@cern.ch" },
   { name = "Farouk Mokhtar" },


### PR DESCRIPTION
When a release is tagged as `test_...`, publishes to https://test.pypi.org/project/particleflow.
When a release is tagged as `v...`, publishes to https://pypi.org/project/particleflow.

Something to note is that the use-case for the PyPI package is limited to running the training, inference and validation, as it does not include the Key4HEP gen-sim submodules. I expect that generally people would want to check out the repository to hack on the code.